### PR TITLE
fix: match events drawer resizer to sidebar style

### DIFF
--- a/src/panel/styles/detail-shell.css
+++ b/src/panel/styles/detail-shell.css
@@ -174,7 +174,7 @@
 .view.active.events-layout {
   display: grid;
   grid-template-columns:
-    minmax(min(100%, var(--events-list-min)), 1fr) 5px
+    minmax(min(100%, var(--events-list-min)), 1fr) 1px
     var(--events-drawer-width, var(--drawer));
   padding: 0;
   overflow: hidden;

--- a/src/panel/styles/events.css
+++ b/src/panel/styles/events.css
@@ -13,11 +13,6 @@
   display: grid;
   grid-template-rows: 37px 1fr;
   overflow: hidden;
-  border-right: 1px solid var(--stroke);
-}
-
-.events-layout:not(.drawer-open) .events-list-pane {
-  border-right: 0;
 }
 
 .pane-search,
@@ -171,14 +166,28 @@ body.is-col-resizing {
   user-select: none !important;
 }
 
-.events-resizer,
-.drag-rail:not(.sidebar-resizer) {
-  background: var(--stroke);
+.events-resizer {
+  position: relative;
+  z-index: 3;
+  width: 1px;
+  min-width: 1px;
   cursor: col-resize;
+  touch-action: none;
+  background: transparent;
+}
+
+.events-resizer::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 8px;
+  transform: translateX(-50%);
 }
 
 .events-resizer:hover,
-.drag-rail:hover,
+.events-resizer.resizing,
 body.is-resizing .events-resizer {
   background: var(--accent);
 }


### PR DESCRIPTION
## Summary
- Narrow the Events drawer splitter from a `5px` stroked bar to a `1px` rail with an `8px` hit area, matching `sidebar-resizer`
- Remove the extra list `border-right` so it does not stack with the rail

## Test plan
- [ ] Open Events drawer and confirm the splitter looks as thin as the sidebar rail
- [ ] Hover / drag the splitter: accent highlight and resize still work
- [ ] Resize at narrow panel widths (responsive drawer overlay)