### PR TITLE
perf: skip empty Events filter copy and shorten row tooltips

### DIFF
--- a/src/panel/views/events-view.ts
+++ b/src/panel/views/events-view.ts
@@ -56,6 +56,8 @@ export function eventMatchesSearch(ev: SseEvent, query: string): boolean {
 
 /** Events currently visible under the Events search filter (ordered). */
 export function getBrowsableEvents(record: StreamRecord): SseEvent[] {
+  // Empty filter: reuse the source array — avoid copying 10k+ events every paint.
+  if (compileTextFilter(state.eventsSearchQuery).isEmpty) return record.events;
   return record.events.filter((ev) => eventMatchesSearch(ev, state.eventsSearchQuery));
 }
 
@@ -336,11 +338,12 @@ export function createEventRow(ev: SseEvent): HTMLTableRowElement {
           eventWarnings.map((w) => specWarningKindLabel(w.kind)).join(", "),
         )}">S</span>`
       : "";
+  const dataPreview = escapeHtml(previewData(ev.data));
   tr.innerHTML = `
     <td class="col-index col-n">${ev.index}${warnMark}</td>
     <td class="col-time">${escapeHtml(formatTime(ev.receivedAt))}</td>
     <td class="col-event">${escapeHtml(ev.event)}</td>
-    <td class="col-data data-cell" title="${escapeHtml(ev.data)}">${escapeHtml(previewData(ev.data))}</td>
+    <td class="col-data data-cell" title="${dataPreview}">${dataPreview}</td>
   `;
   tr.addEventListener("click", () => {
     hideContextMenu();


### PR DESCRIPTION
## Summary
- Reuse `record.events` when the Events search filter is empty (no 10k-array copy each paint)
- Use short `previewData` for the data-cell `title` tooltip instead of the full payload

## Test plan
- [x] `pnpm exec prettier --check src/panel/views/events-view.ts`
- [x] `pnpm typecheck && pnpm test-only && pnpm build`
- [ ] Demo 10k stream with empty search: Events list still scrolls/filters correctly
- [ ] Hover a long data cell: tooltip shows truncated preview; drawer still has full data
- [ ] Non-empty Events search still filters as before
