### PR TITLE
docs: remove pre-launch store and maintainer memos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,12 +64,3 @@ Use the Feature request template. Describe the problem first, then the proposed 
 
 - Current tests cover shared parsers / export / spec / timing / request-view / close / AI merge helpers. They do **not** fully cover the DevTools panel UI or every inject edge case.
 - AI Conversation merge is implemented for several Web profiles (see README vendor matrix). Anthropic is detected as a profile but Conversation merge is not implemented yet. Deeper ReadableStream hooks (`pipeThrough` / `pipeTo`) remain out of scope until we have a confirmed miss-capture case.
-
-## Maintainers: go public & branch protection
-
-Keep the repo **Private** until the Chrome Web Store listing is approved and live. Then:
-
-1. Put the store URL into `README.md` / `README.zh-CN.md`.
-2. Change visibility to **Public**.
-3. Protect `main` — require PRs + status check **`lint / test / typecheck / build`** (needs Public or GitHub Pro).
-4. Set About homepage to the store URL; confirm description / topics.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@
 <p align="center"><a href="./README.zh-CN.md">中文</a></p>
 
 <p align="center">
-  <strong>Chrome Web Store:</strong> listing submitted and <em>under review</em>.<br/>
-  This is the official project — please do not republish the same extension under another developer account.<br/>
-  Store link will be added here when the listing is live.
-</p>
-
-<p align="center">
   <strong>A Chrome extension to debug SSE / EventSource / NDJSON streams in DevTools.</strong><br/>
   After install, open F12 → SSE DevTools to inspect events, conversation, timeline, and global search.<br/>
   Built for long-lived streams such as AI chats, notifications, and progress updates.
@@ -35,7 +29,6 @@
 ---
 
 <p align="center">
-  <!-- SCREENSHOT: hero / panel overview -->
   <img width="1400" alt="Panel overview" src="docs/assets/screenshots/panel-overview.gif">
 </p>
 
@@ -376,7 +369,6 @@ pnpm format:check && pnpm lint && pnpm test && pnpm typecheck && pnpm build
 - How we decide a response is a stream: first check the response `Content-Type` for real stream types (`text/event-stream`, NDJSON, Connect+JSON). Many AI gateways mislabel or omit it — the body is still SSE, but the header says `application/json` / `text/plain`, or there is no `Content-Type` at all. In those cases we also look at the request: `Accept: text/event-stream`, a JSON body with `"stream": true`, or `?stream=true` on the URL. The demo button **Fetch SSE (JSON CT)** is that case (JSON response header + `stream: true` in the body). Ordinary JSON APIs without those hints are still ignored
 - Conversation depends on each site’s private protocol and may need updates after site changes
 - If the SSE panel opens after a stream already started, the background service worker replays a recent buffer (up to ~2 000 messages / ~4 MB per tab). Older traffic may be dropped when the cap is hit; an extension service-worker restart can still clear the buffer
-- Until the Chrome Web Store listing is live, run `pnpm build` locally and load `dist/` from the extensions page
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,12 +11,6 @@
 <p align="center"><a href="./README.md">English</a></p>
 
 <p align="center">
-  <strong>Chrome 网上应用店：</strong>已提交上架，<em>审核中</em>。<br/>
-  本仓库为官方项目，请勿用其他开发者账号重复上架同一扩展。<br/>
-  审核通过后会在此补充商店链接。
-</p>
-
-<p align="center">
   <strong>Chrome 扩展：在 DevTools 里调试网页的 SSE / EventSource / NDJSON 流。</strong><br/>
   安装后打开 F12 → SSE DevTools：事件列表、对话、时间线与全局搜索，都能在面板里直接看。<br/>
   适合 AI 对话、通知推送、进度上报等长连接场景。
@@ -35,7 +29,6 @@
 ---
 
 <p align="center">
-  <!-- SCREENSHOT: hero / panel overview -->
   <img width="1400" alt="面板总览" src="docs/assets/screenshots/panel-overview.gif">
 </p>
 
@@ -408,7 +401,6 @@ pnpm format:check && pnpm lint && pnpm test && pnpm typecheck && pnpm build
 - 扩展怎么判断「这是一条要抓的流」：先看响应头有没有正经流类型（如 `Content-Type: text/event-stream` / NDJSON / Connect+JSON）。很多 AI 网关会标错或干脆不标——响应仍是 SSE 正文，但写成 `application/json`、`text/plain`，或响应头里根本没有 `Content-Type`。这时会再看请求是否像在要流：例如 `Accept: text/event-stream`、POST body 含 `"stream": true`、URL 带 `?stream=true`。Demo 里的 **Fetch SSE (JSON CT)** 就是「响应标成 JSON、请求 body 带 stream:true」这种。普通查用户资料一类的 JSON 接口没有这些提示，仍然不会进侧栏
 - 对话视图依赖各站私有协议，站点改版后可能需要重新适配
 - 若流已开始后再打开 SSE 面板，background 会回放该 tab 的近期缓冲（约 2000 条 / 4MB 上限）；超限会丢最旧数据，扩展 Service Worker 被回收后缓冲也会清空
-- 在 Chrome 网上应用店上架生效前，需本地 `pnpm build` 后，在扩展管理页加载 `dist/` 使用
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove Chrome Web Store under-review banners from both READMEs
- Drop screenshot TODO HTML comments and pre-listing install caveats
- Remove the CONTRIBUTING maintainer go-public checklist

## Test plan
- [x] Grep confirms no leftover under-review / go-public memo phrasing