### PR TITLE
fix: stop treating all kimi hosts as connect-json streams

### DIFF
--- a/src/content/inject/__tests__/detect.test.ts
+++ b/src/content/inject/__tests__/detect.test.ts
@@ -65,5 +65,22 @@ describe("detect", () => {
       }) === "connect-json",
       "connect accept",
     );
+
+    assert(
+      resolveStreamKind({
+        responseContentType: "application/json",
+        url: "https://www.kimi.com/update.json?t=1",
+      }) === null,
+      "kimi host alone does not capture",
+    );
+
+    assert(
+      resolveStreamKind({
+        responseContentType: "application/connect+json",
+        requestHeaders: { "content-type": "application/connect+json" },
+        url: "https://www.kimi.com/apiv2/kimi.gateway.chat.v1.ChatService/Chat",
+      }) === "connect-json",
+      "kimi Chat connect+json still captured",
+    );
   });
 });

--- a/src/content/inject/detect.ts
+++ b/src/content/inject/detect.ts
@@ -21,22 +21,6 @@ export function detectStreamKind(contentType: string | null | undefined): Stream
   return null;
 }
 
-/** Kimi.com web uses Connect+JSON (not api.moonshot OpenAI SSE). */
-export function looksLikeKimiConnectUrl(url: string): boolean {
-  try {
-    const host = new URL(url, "https://dummy.local").hostname.toLowerCase();
-    if (host.includes("api.moonshot.")) return false;
-    return (
-      host.includes("kimi.com") ||
-      host.includes("kimi.ai") ||
-      host === "kimi.moonshot.cn" ||
-      host.endsWith(".moonshot.cn")
-    );
-  } catch {
-    return /kimi\.com|kimi\.ai/i.test(url);
-  }
-}
-
 export function requestLooksLikeConnectJson(headers?: Record<string, string>): boolean {
   if (!headers) return false;
   const accept = (headers.accept ?? "").toLowerCase();
@@ -111,7 +95,6 @@ export function resolveStreamKind(input: ResolveStreamKindInput): StreamKind | n
   if (fromCt) return fromCt;
 
   if (requestLooksLikeConnectJson(input.requestHeaders)) return "connect-json";
-  if (input.url && looksLikeKimiConnectUrl(input.url)) return "connect-json";
 
   if (requestAcceptsEventStream(input.requestHeaders)) return "sse";
   if (requestAcceptsNdjson(input.requestHeaders)) return "ndjson";


### PR DESCRIPTION
## Summary
- Remove the overly broad `looksLikeKimiConnectUrl` heuristic that classified every `kimi.com` / `moonshot.cn` request as a Connect+JSON stream.
- Keep capture based on `application/connect+json` response/request headers so real Kimi `ChatService/Chat` streams still appear.
- Add regression tests that `update.json` is ignored while Chat connect+json is still captured.

## Test plan
- [x] `pnpm test -- src/content/inject/__tests__/detect.test.ts`
- [ ] Reload extension on kimi.com, send a chat: Streams should list `ChatService/Chat` and not flood with `update.json` / unary RPCs / static assets