### PR TITLE
fix: strip Kimi citation chips from Conversation content

### DIFF
--- a/src/shared/ai-merge/__tests__/index.test.ts
+++ b/src/shared/ai-merge/__tests__/index.test.ts
@@ -452,6 +452,43 @@ describe("ai-merge", () => {
       assert(t.channels.tools[0].name === "web_search", "kimi web_search");
       assert(t.endMeta.finishReason === "stop", "kimi finish");
       assert(conversationHasContent(t), "kimi has content");
+
+      // Citation chips in block.text must not leak into Content tab
+      const citeChip =
+        "\uE3A0article\u{1F6E0}web_search:16#7\u{1F6E0}web_search:16#5\u{1F6E0}web_search:16#9\uE3A8";
+      const citeEvents = [
+        ev(
+          JSON.stringify({
+            op: "append",
+            mask: "block.text.content",
+            block: { id: "c1", parentId: "", text: { content: " " } },
+          }),
+          "block.text.content",
+        ),
+        ev(
+          JSON.stringify({
+            op: "append",
+            mask: "block.text.content",
+            block: { id: "c1", parentId: "", text: { content: citeChip } },
+          }),
+          "block.text.content",
+        ),
+        ev(
+          JSON.stringify({
+            op: "append",
+            mask: "block.text.content",
+            block: { id: "c1", parentId: "", text: { content: "## 合肥天气" } },
+          }),
+          "block.text.content",
+        ),
+      ];
+      const citeMerged = mergeAiConversation(citeEvents, "https://www.kimi.com/chat");
+      assert(citeMerged.profile === "kimi-web", "cite profile");
+      assert(!citeMerged.channels.content.includes("web_search:"), "cite chip stripped");
+      assert(!citeMerged.channels.content.includes("article"), "article chip stripped");
+      assert(!citeMerged.channels.content.includes("\uE3A0"), "pua start stripped");
+      assert(citeMerged.channels.content.includes("## 合肥天气"), "real answer kept");
+      assert(citeMerged.channels.content.trim().startsWith("##"), "no leading whitespace seed");
     }
 
     {

--- a/src/shared/ai-merge/index.ts
+++ b/src/shared/ai-merge/index.ts
@@ -35,7 +35,7 @@ export {
 } from "./doubao";
 
 export type { KimiWebMergeState } from "./kimi";
-export { createKimiWebMergeState, pushKimiWeb, snapshotKimiWeb, mergeKimiWeb } from "./kimi";
+export { createKimiWebMergeState, pushKimiWeb, snapshotKimiWeb, mergeKimiWeb, sanitizeKimiAnswerText } from "./kimi";
 
 export type { QwenWebMergeState } from "./qwen";
 export {

--- a/src/shared/ai-merge/kimi.ts
+++ b/src/shared/ai-merge/kimi.ts
@@ -32,6 +32,19 @@ export function createKimiWebMergeState(): KimiWebMergeState {
 }
 
 /**
+ * Strip Kimi inline citation chips embedded in answer text.
+ * Runtime shape (Connect+JSON block.text): \uE3A0article🛠web_search:N#M…\uE3A8
+ */
+export function sanitizeKimiAnswerText(text: string): string {
+  if (!text) return text;
+  let out = text.replace(/\uE3A0[\s\S]*?\uE3A8/g, "");
+  // Orphan hammer + ref tokens if delimiters were split across chunks
+  out = out.replace(/\u{1F6E0}web_search:\d+#\d+/gu, "");
+  out = out.replace(/\uE3A0|\uE3A8/g, "");
+  return out;
+}
+
+/**
  * Kimi.com Connect+JSON (real capture / Bridge-compatible):
  * - mask chat.lastRequest / heartbeat → ignore
  * - mask message role=user → ignore; assistant status completed → finish
@@ -75,8 +88,15 @@ export function pushKimiWeb(
     return false;
   };
 
-  const pushText = (text: string, channel: "content" | "reasoning") => {
-    if (!text) return;
+  const pushText = (raw: string, channel: "content" | "reasoning") => {
+    let text = raw;
+    if (channel === "content") {
+      text = sanitizeKimiAnswerText(text);
+      // Do not seed Content tab with whitespace-only crumbs while thinking streams
+      if (!text || (!state.content && /^\s*$/.test(text))) return;
+    } else if (!text) {
+      return;
+    }
     state.chunkCount++;
     if (channel === "reasoning") state.reasoning += text;
     else state.content += text;


### PR DESCRIPTION
## Summary
- Sanitize Kimi answer text by removing `\uE3A0…\uE3A8` citation chips (`article` + `web_search:N#M`) before they reach the Content channel.
- Ignore whitespace-only content crumbs while Content is still empty so the Content tab no longer shows `(1)/(2)` during thinking.
- Add regression coverage for the captured chip shape.

## Test plan
- [x] `pnpm test -- src/shared/ai-merge/__tests__/index.test.ts`
- [ ] Reload extension on kimi.com with a search-backed answer: Content has no `article` / `web_search:…` garbage; badge stays empty until real text arrives