### PR TITLE
fix: stop Raw/Conversation virtual scroll runaway

### DIFF
--- a/src/panel/styles/conversation.css
+++ b/src/panel/styles/conversation.css
@@ -104,11 +104,13 @@
   white-space: normal;
   word-break: normal;
   padding: 9px 11px;
+  overflow-anchor: none;
 }
 
 .conversation-virtual-spacer {
   width: 100%;
   pointer-events: none;
+  overflow-anchor: none;
 }
 
 .conversation-virtual-window {
@@ -121,7 +123,9 @@
   white-space: pre;
   word-break: normal;
   line-height: 18px;
-  overflow: visible;
+  overflow: hidden;
+  box-sizing: border-box;
+  overflow-anchor: none;
 }
 
 .conversation-virtual-window.is-empty {

--- a/src/panel/styles/raw.css
+++ b/src/panel/styles/raw.css
@@ -29,11 +29,13 @@
   display: block;
   white-space: normal;
   word-break: normal;
+  overflow-anchor: none;
 }
 
 .raw-virtual-spacer {
   width: 100%;
   pointer-events: none;
+  overflow-anchor: none;
 }
 
 .raw-virtual-window {
@@ -46,5 +48,7 @@
   white-space: pre;
   word-break: normal;
   line-height: 18px;
-  overflow: visible;
+  overflow: hidden;
+  box-sizing: border-box;
+  overflow-anchor: none;
 }

--- a/src/panel/views/conversation-view.ts
+++ b/src/panel/views/conversation-view.ts
@@ -71,13 +71,19 @@ function disposeVirtualTextPane(): void {
 }
 
 function onVirtualScroll(): void {
-  if (activeVirtualPane) paintVirtualWindow(activeVirtualPane, false);
+  if (!activeVirtualPane) return;
+  const pinnedScrollTop = activeVirtualPane.root.scrollTop;
+  paintVirtualWindow(activeVirtualPane, false);
+  if (activeVirtualPane.root.scrollTop !== pinnedScrollTop) {
+    activeVirtualPane.root.scrollTop = pinnedScrollTop;
+  }
 }
 
 function paintVirtualWindow(pane: VirtualTextPane, force: boolean): void {
   if (pane.empty) {
     pane.topSpacer.style.height = "0px";
     pane.bottomSpacer.style.height = "0px";
+    pane.windowEl.style.height = "";
     pane.paintedStart = 0;
     pane.paintedEnd = 0;
     return;
@@ -87,14 +93,17 @@ function paintVirtualWindow(pane: VirtualTextPane, force: boolean): void {
     pane.root.clientHeight || 1,
     pane.rows.length,
   );
+  const expectedWinH = Math.max(0, win.end - win.start) * CONV_ROW_HEIGHT_PX;
   if (!force && win.start === pane.paintedStart && win.end === pane.paintedEnd) {
     pane.topSpacer.style.height = `${win.paddingTop}px`;
     pane.bottomSpacer.style.height = `${win.paddingBottom}px`;
+    pane.windowEl.style.height = `${expectedWinH}px`;
     return;
   }
   pane.topSpacer.style.height = `${win.paddingTop}px`;
   pane.bottomSpacer.style.height = `${win.paddingBottom}px`;
   pane.windowEl.textContent = pane.rows.slice(win.start, win.end).join("\n");
+  pane.windowEl.style.height = `${expectedWinH}px`;
   pane.paintedStart = win.start;
   pane.paintedEnd = win.end;
 }
@@ -138,7 +147,7 @@ function createVirtualTextPane(): VirtualTextPane {
     pane.rows = wrapTextToRows(pane.text, nextCols);
     pane.paintedStart = -1;
     paintVirtualWindow(pane, true);
-    if (near) pane.root.scrollTop = pane.rows.length * CONV_ROW_HEIGHT_PX;
+    if (near) pane.root.scrollTop = pane.root.scrollHeight;
   });
   pane.ro.observe(root);
   activeVirtualPane = pane;
@@ -173,7 +182,7 @@ function setVirtualText(pane: VirtualTextPane, nextText: string, showingEmpty: b
   pane.paintedStart = -1;
   paintVirtualWindow(pane, true);
   lastRenderedChannelText = nextText;
-  if (near) pane.root.scrollTop = pane.rows.length * CONV_ROW_HEIGHT_PX;
+  if (near) pane.root.scrollTop = pane.root.scrollHeight;
 }
 
 function buildConversationFingerprint(

--- a/src/panel/views/raw-view.ts
+++ b/src/panel/views/raw-view.ts
@@ -48,7 +48,7 @@ function ensureStructure(): void {
       rawRows = wrapTextToRows(lastRawShown, nextCols);
       paintedStart = -1;
       paintRawWindow(true);
-      if (near) elRaw.scrollTop = rawRows.length * CONV_ROW_HEIGHT_PX;
+      if (near) elRaw.scrollTop = elRaw.scrollHeight;
     });
     resizeObserver.observe(elRaw);
   }
@@ -56,7 +56,12 @@ function ensureStructure(): void {
 }
 
 function onRawScroll(): void {
+  // Preserve scroll position across spacer rewrites (Chrome scroll anchoring).
+  const pinnedScrollTop = elRaw.scrollTop;
   paintRawWindow(false);
+  if (elRaw.scrollTop !== pinnedScrollTop) {
+    elRaw.scrollTop = pinnedScrollTop;
+  }
 }
 
 function paintRawWindow(force: boolean): void {
@@ -66,19 +71,24 @@ function paintRawWindow(force: boolean): void {
     topSpacer.style.height = "0px";
     bottomSpacer.style.height = "0px";
     windowEl.textContent = "";
+    windowEl.style.height = "0px";
     paintedStart = 0;
     paintedEnd = 0;
     return;
   }
   const win = computeConvVirtualWindow(elRaw.scrollTop, elRaw.clientHeight || 1, rawRows.length);
+  const expectedWinH = Math.max(0, win.end - win.start) * CONV_ROW_HEIGHT_PX;
   if (!force && win.start === paintedStart && win.end === paintedEnd) {
     topSpacer.style.height = `${win.paddingTop}px`;
     bottomSpacer.style.height = `${win.paddingBottom}px`;
+    windowEl.style.height = `${expectedWinH}px`;
     return;
   }
   topSpacer.style.height = `${win.paddingTop}px`;
   bottomSpacer.style.height = `${win.paddingBottom}px`;
   windowEl.textContent = rawRows.slice(win.start, win.end).join("\n");
+  // Lock window box to ideal row geometry so spacer+window never oscillates scrollHeight.
+  windowEl.style.height = `${expectedWinH}px`;
   paintedStart = win.start;
   paintedEnd = win.end;
 }
@@ -129,6 +139,6 @@ export function renderRawView(
   paintRawWindow(true);
 
   if (stick && (nearBottom || !sameStream || plan.mode === "replace")) {
-    elRaw.scrollTop = rawRows.length * CONV_ROW_HEIGHT_PX;
+    elRaw.scrollTop = elRaw.scrollHeight;
   }
 }


### PR DESCRIPTION
## Summary
- Lock virtual text window height to `(end - start) * rowHeight` and stick-to-bottom via `scrollHeight`.
- Disable Chrome scroll anchoring on virtual panes/spacers and pin `scrollTop` after paint so wheel input no longer triggers an infinite scroll feedback loop.
- Apply the same fix to Conversation virtual text panes.

## Test plan
- [x] Stream into Raw: scrollbar stays pinned to bottom while generating
- [x] After stream ends, mouse wheel scrolls normally without runaway
- [ ] Confirm CI is green