### PR TITLE
fix: merge Qwen bar/workflow thinking and weather tools

### DIFF
--- a/fixtures/vendors/qwen/events.json
+++ b/fixtures/vendors/qwen/events.json
@@ -26,5 +26,17 @@
   {
     "event": "message",
     "data": "{\"error_msg\":\"\",\"error_code\":0,\"data\":{\"extra_info\":{\"agent_name\":\"AgentProxy\",\"scene\":\"deep_think_r1lite\",\"sse_end\":\"1\"},\"messages\":[{\"mime_type\":\"multi_load/iframe\",\"meta_data\":{\"multi_load\":[]},\"content\":\"[(deep_think)]\\n\\ntoday is partly cloudy, 26-33C.\",\"status\":\"complete\"}]}}"
+  },
+  {
+    "event": "message",
+    "data": "{\"error_msg\":\"\",\"error_code\":0,\"data\":{\"extra_info\":{\"agent_name\":\"AgentProxy\",\"scene\":\"qwen_expert\"},\"messages\":[{\"mime_type\":\"bar/workflow\",\"meta_data\":{\"multi_load\":[{\"type\":\"bar_thinking\",\"content\":{\"body\":\"Call the weather tool for tomorrow.\",\"title\":\"Look up city weather\",\"status\":\"processing\"},\"source_seq\":\"bar_thinking_1\"}]},\"content\":\"\",\"status\":\"processing\"}]}}"
+  },
+  {
+    "event": "message",
+    "data": "{\"error_msg\":\"\",\"error_code\":0,\"data\":{\"extra_info\":{\"agent_name\":\"AgentProxy\",\"scene\":\"qwen_expert\"},\"messages\":[{\"mime_type\":\"bar/workflow\",\"meta_data\":{\"multi_load\":[{\"type\":\"bar_thinking\",\"content\":{\"body\":\"Call the weather tool for tomorrow.\",\"title\":\"Look up city weather\",\"status\":\"complete\"},\"source_seq\":\"bar_thinking_1\"},{\"type\":\"bar_tool\",\"content\":{\"body\":\"\",\"title\":\"Use the weather tool to query the 1-day forecast\",\"icon_type\":\"ICON_WRENCH\",\"status\":\"complete\"},\"source_seq\":\"bar_tool_1\"}]},\"content\":\"\",\"status\":\"processing\"}]}}"
+  },
+  {
+    "event": "message",
+    "data": "{\"error_msg\":\"\",\"error_code\":0,\"data\":{\"extra_info\":{\"agent_name\":\"AgentProxy\",\"scene\":\"qwen_expert\"},\"messages\":[{\"mime_type\":\"bar/workflow\",\"meta_data\":{\"multi_load\":[{\"type\":\"bar_thinking\",\"content\":{\"body\":\"Call the weather tool for tomorrow.\",\"title\":\"Look up city weather\",\"status\":\"complete\"},\"source_seq\":\"bar_thinking_1\"},{\"type\":\"bar_tool\",\"content\":{\"body\":\"\",\"title\":\"Use the weather tool to query the 1-day forecast\",\"icon_type\":\"ICON_WRENCH\",\"status\":\"complete\"},\"source_seq\":\"bar_tool_1\"},{\"type\":\"bar_thinking\",\"content\":{\"body\":\"Summarize the weather tool result.\",\"title\":\"Summarize city weather\",\"status\":\"complete\"},\"source_seq\":\"bar_thinking_2\"}]},\"content\":\"\",\"status\":\"complete\"}]}}"
   }
 ]

--- a/fixtures/vendors/qwen/expect.json
+++ b/fixtures/vendors/qwen/expect.json
@@ -2,7 +2,12 @@
   "url": "https://www.qianwen.com/chat",
   "profile": "qwen-web",
   "vendorHint": "qwen",
-  "reasoningIncludes": ["user asked about weather", "based on search results"],
+  "reasoningIncludes": [
+    "user asked about weather",
+    "based on search results",
+    "Call the weather tool",
+    "Summarize the weather tool result"
+  ],
   "contentIncludes": ["today is partly cloudy"],
   "contentExcludes": ["I need to answer about weather"],
   "minTools": 1,

--- a/src/shared/ai-merge/__tests__/qwen-weather-dump.test.ts
+++ b/src/shared/ai-merge/__tests__/qwen-weather-dump.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { mergeAiConversation } from "../index";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../");
+const eventsPath = resolve(repoRoot, "fixtures/vendors/qwen/events.json");
+
+type FixtureEvent = { data: string; event?: string };
+
+describe("qwen weather dump", () => {
+  it("merges bar/workflow thinking and weather tool from the qwen fixture", () => {
+    expect(existsSync(eventsPath), `missing ${eventsPath}`).toBe(true);
+    const events = JSON.parse(readFileSync(eventsPath, "utf8")) as FixtureEvent[];
+    const merged = mergeAiConversation(
+      events.map((e) => ({ data: e.data, event: e.event ?? "message" })),
+      "https://www.qianwen.com/chat",
+    );
+    expect(merged.profile).toBe("qwen-web");
+    expect(merged.channels.tools[0]?.name).toBe("web_search");
+    const weather = merged.channels.tools.find((t) => t.id === "bar_tool_1");
+    expect(weather?.name).toBe("weather");
+    const args = JSON.parse(weather?.arguments ?? "{}") as { query?: string; body?: string };
+    expect(args.query).toContain("weather");
+    expect(args.body).toBeUndefined();
+    expect(merged.channels.reasoning).toContain("Call the weather tool");
+    expect(merged.channels.reasoning).toContain("Summarize the weather tool result");
+    expect(merged.channels.content).toContain("today is partly cloudy");
+  });
+});

--- a/src/shared/ai-merge/qwen.ts
+++ b/src/shared/ai-merge/qwen.ts
@@ -37,6 +37,14 @@ export function collapseCumulativeLines(text: string): string {
   return out.join("\n");
 }
 
+/** Short function name for `bar/workflow` tool chips; keep the human title in arguments.query. */
+export function qwenWorkflowToolName(title: string): string {
+  if (/天气|weather/i.test(title)) return "weather";
+  const used = title.match(/^使用(.+?)(?:工具)?[，,]/);
+  const extracted = used?.[1]?.trim();
+  return extracted || "tool";
+}
+
 export type QwenWebMergeState = {
   content: string;
   reasoning: string;
@@ -46,6 +54,8 @@ export type QwenWebMergeState = {
   snapshots: Map<string, string>;
   planCotLatest: string;
   deepThinkLatest: string;
+  /** `bar/workflow` thinking snapshots keyed by source_seq. */
+  workflowThinkBySeq: Map<string, string>;
 };
 
 export function createQwenWebMergeState(): QwenWebMergeState {
@@ -58,6 +68,7 @@ export function createQwenWebMergeState(): QwenWebMergeState {
     snapshots: new Map(),
     planCotLatest: "",
     deepThinkLatest: "",
+    workflowThinkBySeq: new Map(),
   };
 }
 
@@ -68,6 +79,7 @@ export function createQwenWebMergeState(): QwenWebMergeState {
  * - multi_load/iframe msg.content (after [(deep_think)] prefix) → content
  * - bar/progress cot query + result list → tools web_search
  * - bar/iframe sources + source_group_web → tools web_search
+ * - bar/workflow multi_load bar_thinking → reasoning; bar_tool → tools
  */
 export function pushQwenWeb(
   state: QwenWebMergeState,
@@ -221,6 +233,44 @@ export function pushQwenWeb(
         continue;
       }
 
+      if (mime === "bar/workflow") {
+        const md = isRecord(msg.meta_data) ? msg.meta_data : null;
+        const multiLoad = md && Array.isArray(md.multi_load) ? md.multi_load : [];
+        for (const item of multiLoad) {
+          if (!isRecord(item)) continue;
+          const seq = asString(item.source_seq) ?? String(item.type ?? "");
+          const bag = isRecord(item.content) ? item.content : null;
+          if (item.type === "bar_thinking" && bag) {
+            const title = asString(bag.title) ?? "";
+            const body = asString(bag.body) ?? "";
+            const text = [title, body].filter(Boolean).join("\n");
+            if (!text) continue;
+            const prev = state.workflowThinkBySeq.get(seq) ?? "";
+            if (text.length >= prev.length) {
+              state.workflowThinkBySeq.set(seq, text);
+              state.chunkCount++;
+            }
+          } else if (item.type === "bar_tool" && bag) {
+            const title = asString(bag.title) ?? "tool";
+            const body = asString(bag.body) ?? "";
+            const id = seq || title;
+            const name = qwenWorkflowToolName(title);
+            const argsObj: Record<string, string> = { query: title };
+            if (body) argsObj.body = body;
+            const args = JSON.stringify(argsObj);
+            const existing = state.tools.find((t) => t.id === id);
+            if (existing) {
+              existing.arguments = args;
+              existing.name = name;
+            } else {
+              state.tools.push({ index: state.tools.length, id, name, arguments: args });
+            }
+            state.chunkCount++;
+          }
+        }
+        continue;
+      }
+
       if (mime === "multi_load/iframe") {
         const md = isRecord(msg.meta_data) ? msg.meta_data : null;
         const multiLoad = md && Array.isArray(md.multi_load) ? md.multi_load : [];
@@ -278,6 +328,9 @@ export function snapshotQwenWeb(state: QwenWebMergeState): MergeChannelsResult {
   const reasoningParts: string[] = [];
   if (planCotCollapsed) reasoningParts.push(planCotCollapsed);
   if (state.deepThinkLatest) reasoningParts.push(state.deepThinkLatest);
+  for (const text of state.workflowThinkBySeq.values()) {
+    if (text) reasoningParts.push(text);
+  }
   state.reasoning = reasoningParts.join("\n\n");
 
   return {

--- a/src/shared/ai-profile.ts
+++ b/src/shared/ai-profile.ts
@@ -183,6 +183,7 @@ const QWEN_WEB_MIME_TYPES = new Set([
   "multi_load/iframe",
   "bar/progress",
   "bar/iframe",
+  "bar/workflow",
   "signal/post",
   "paa/iframe",
 ]);


### PR DESCRIPTION
## Summary
- Merge Tongyi/Qwen `bar/workflow` `bar_thinking` into Conversation reasoning, and `bar_tool` into tools (weather chips use `name: weather` with the human title in `arguments.query`).
- Recognize `bar/workflow` in the Qwen web profile, and extend the existing sanitized `qwen` vendor fixture instead of committing a live dump.

## Checklist
- [x] pnpm format:check && pnpm lint && pnpm test && pnpm typecheck && pnpm build passes locally
- [ ] UI / capture changes were smoke-tested (pnpm demo or a real page)
- [x] Shared logic changes include or update tests when practical
- [x] No secrets or personal data in fixtures / screenshots
- [x] If detect / i-merge / vendor fixtures changed, pnpm test covers them

## Test plan
- [ ] On chat2.qianwen.com, ask a weather question that triggers a tool (e.g. 明天深圳天气).
- [ ] Conversation reasoning includes workflow thinking text; Tools shows a `weather` card, not a duplicated Chinese title.
- [ ] Existing Qwen `web_search` fixture path still passes (`tools[0]` remains `web_search`).
- [ ] `pnpm test` including `vendor-fixtures` and `qwen-weather-dump`.