### PR TITLE
feat: truncate long JSON string leaves like Network panel

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -13,7 +13,7 @@ All of the following stays on the developer’s machine unless the developer exp
 - Streaming response bodies the page already receives (assembled raw text and parsed events).
 - Request metadata collected from the page when available: URL, method, status, Content-Type, transport.
 - Request and response headers after automatic redaction of common sensitive header names (for example `Authorization`, `Cookie`, and many `*token*` / `*api-key*` style headers). Redaction follows known naming patterns and may not cover every custom header name.
-- A text preview of the request body when available (capped; currently up to 256,000 characters). Truncation is indicated in the UI when applicable.
+- A text preview of the request body when available (capped; currently up to 256,000 characters). Truncation is indicated in the UI when applicable. Long string fields in the Parsed JSON view are abbreviated in the UI (Show more / Copy), similar to the Network panel.
 - Derived debugging views built from the above (Events, Timeline, Raw, Request, Conversation merge output for supported profiles).
 
 ### Stored on the device

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -846,16 +846,19 @@
     "message": "No request payload (GET/EventSource, or body unavailable)."
   },
   "jsonShowMore": {
-    "message": "show more"
+    "message": "Show more"
   },
   "jsonShowLess": {
-    "message": "show less"
+    "message": "Show less"
   },
   "jsonCopyValue": {
     "message": "Copy value"
   },
   "jsonCopyPath": {
     "message": "Copy path"
+  },
+  "jsonStringSize": {
+    "message": "~$1"
   },
   "exportMenu": {
     "message": "Export"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -857,6 +857,9 @@
   "jsonCopyPath": {
     "message": "复制路径"
   },
+  "jsonStringSize": {
+    "message": "约 $1"
+  },
   "exportMenu": {
     "message": "导出"
   },

--- a/src/panel/core/format.ts
+++ b/src/panel/core/format.ts
@@ -46,6 +46,14 @@ export function formatMetricMs(ms?: number): string {
   return `${Math.round(ms)} ms`;
 }
 
+/** Approximate size label for long string fields (char-count based). */
+export function formatApproxSize(charCount: number): string {
+  if (!Number.isFinite(charCount) || charCount < 0) return "0 B";
+  if (charCount < 1024) return `${Math.round(charCount)} B`;
+  if (charCount < 1024 * 1024) return `${(charCount / 1024).toFixed(1)} KB`;
+  return `${(charCount / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 export function formatGapBinLabel(bin: HistogramBin): string {
   if (!Number.isFinite(bin.toMs)) {
     return bin.fromMs >= 1000 ? `≥${bin.fromMs / 1000}s` : `≥${bin.fromMs}ms`;

--- a/src/panel/styles/widgets.css
+++ b/src/panel/styles/widgets.css
@@ -75,6 +75,37 @@
 
 .json-value.json-string {
   color: var(--json-string);
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.json-value.json-string.is-expanded {
+  display: inline;
+  max-width: 100%;
+}
+
+.json-string-meta {
+  color: var(--text-faint);
+  font-size: var(--text-xs);
+  font-family: var(--sans);
+  flex-shrink: 0;
+}
+
+.json-string-action {
+  border: none;
+  background: transparent;
+  color: var(--accent-strong);
+  font: inherit;
+  font-family: var(--sans);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  padding: 0 2px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.json-string-action:hover {
+  text-decoration: underline;
 }
 
 .json-value.json-number {

--- a/src/panel/views/events-view.ts
+++ b/src/panel/views/events-view.ts
@@ -19,6 +19,7 @@ import {
   elTbody,
 } from "../core/dom";
 import { escapeHtml, formatTime, previewData } from "../core/format";
+import { copyText } from "../core/ui-chrome";
 import { applyTreeSearch, createJsonTree, tryParseJsonValue } from "../widgets/json-tree";
 import {
   getStreamSpecWarnings,
@@ -403,6 +404,12 @@ export function bindJsonTreeContextMenu(tree: HTMLElement): void {
   tree.addEventListener("json-tree-contextmenu", (event) => {
     const e = event as CustomEvent<{ x: number; y: number; path: string; copyValue?: string }>;
     showJsonTreeContextMenu(e.detail.x, e.detail.y, e.detail.path, e.detail.copyValue);
+  });
+  tree.addEventListener("json-tree-copy", (event) => {
+    const e = event as CustomEvent<{ value: string }>;
+    if (typeof e.detail?.value === "string") {
+      void copyText(e.detail.value, true);
+    }
   });
 }
 

--- a/src/panel/widgets/__tests__/json-tree.test.ts
+++ b/src/panel/widgets/__tests__/json-tree.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { formatApproxSize } from "../../core/format";
+import { JSON_STRING_PREVIEW_CHARS, formatCollapsedJsonString } from "../json-tree";
+
+describe("formatApproxSize", () => {
+  it("formats bytes / KB / MB", () => {
+    expect(formatApproxSize(0)).toBe("0 B");
+    expect(formatApproxSize(120)).toBe("120 B");
+    expect(formatApproxSize(2048)).toBe("2.0 KB");
+    expect(formatApproxSize(1024 * 1024)).toBe("1.0 MB");
+  });
+});
+
+describe("formatCollapsedJsonString", () => {
+  it("returns full JSON string under the preview limit", () => {
+    expect(formatCollapsedJsonString("hello")).toBe('"hello"');
+  });
+
+  it("truncates long strings with ellipsis inside quotes", () => {
+    const raw = "a".repeat(JSON_STRING_PREVIEW_CHARS + 20);
+    const out = formatCollapsedJsonString(raw);
+    expect(out.startsWith('"')).toBe(true);
+    expect(out.endsWith('"')).toBe(true);
+    expect(out.includes("…")).toBe(true);
+    expect(out.length).toBeLessThan(JSON.stringify(raw).length);
+  });
+});

--- a/src/panel/widgets/json-tree.ts
+++ b/src/panel/widgets/json-tree.ts
@@ -1,8 +1,17 @@
 import { compileTextFilter } from "../../shared/text-filter";
+import { t } from "../../shared/i18n";
+import { formatApproxSize } from "../core/format";
 
 /**
  * Build an expandable JSON tree.
  */
+
+/** Collapse string leaf display past this many content characters (Network-like). */
+export const JSON_STRING_PREVIEW_CHARS = 120;
+
+export type JsonTreeCopyDetail = {
+  value: string;
+};
 
 export function tryParseJsonValue(text: string): { ok: true; value: unknown } | { ok: false } {
   const trimmed = text.trim();
@@ -28,6 +37,15 @@ export function tryParseJsonValue(text: string): { ok: true; value: unknown } | 
   }
 
   return { ok: false };
+}
+
+/** Format a JSON string leaf for collapsed display (quotes + truncated content). */
+export function formatCollapsedJsonString(
+  raw: string,
+  maxChars = JSON_STRING_PREVIEW_CHARS,
+): string {
+  if (raw.length <= maxChars) return JSON.stringify(raw);
+  return JSON.stringify(raw.slice(0, maxChars) + "…");
 }
 
 export function createJsonTree(
@@ -338,10 +356,14 @@ function renderLeaf(key: string | null, value: unknown, type: string, path: stri
     line.appendChild(document.createTextNode(": "));
   }
 
-  const valEl = document.createElement("span");
-  valEl.className = `json-value json-${type}`;
-  valEl.textContent = formatted;
-  line.appendChild(valEl);
+  if (type === "string" && typeof value === "string" && value.length > JSON_STRING_PREVIEW_CHARS) {
+    appendCollapsibleStringValue(line, value);
+  } else {
+    const valEl = document.createElement("span");
+    valEl.className = `json-value json-${type}`;
+    valEl.textContent = formatted;
+    line.appendChild(valEl);
+  }
 
   line.addEventListener("click", () => {
     setActiveLine(line);
@@ -365,6 +387,60 @@ function renderLeaf(key: string | null, value: unknown, type: string, path: stri
 
   row.appendChild(line);
   return row;
+}
+
+function appendCollapsibleStringValue(line: HTMLElement, raw: string): void {
+  const fullFormatted = JSON.stringify(raw);
+  const collapsedFormatted = formatCollapsedJsonString(raw);
+
+  const valEl = document.createElement("span");
+  valEl.className = "json-value json-string";
+  valEl.textContent = collapsedFormatted;
+
+  const meta = document.createElement("span");
+  meta.className = "json-string-meta";
+  meta.textContent = t("jsonStringSize", formatApproxSize(raw.length));
+
+  const toggleBtn = document.createElement("button");
+  toggleBtn.type = "button";
+  toggleBtn.className = "json-string-action";
+  toggleBtn.textContent = t("jsonShowMore");
+
+  const copyBtn = document.createElement("button");
+  copyBtn.type = "button";
+  copyBtn.className = "json-string-action";
+  copyBtn.textContent = t("jsonCopyValue");
+  copyBtn.title = t("jsonCopyValue");
+
+  let expanded = false;
+  const refresh = (): void => {
+    valEl.textContent = expanded ? fullFormatted : collapsedFormatted;
+    valEl.classList.toggle("is-expanded", expanded);
+    toggleBtn.textContent = expanded ? t("jsonShowLess") : t("jsonShowMore");
+  };
+
+  toggleBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    setActiveLine(line);
+    expanded = !expanded;
+    refresh();
+  });
+
+  copyBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    setActiveLine(line);
+    line.dispatchEvent(
+      new CustomEvent<JsonTreeCopyDetail>("json-tree-copy", {
+        bubbles: true,
+        detail: { value: raw },
+      }),
+    );
+  });
+
+  line.appendChild(valEl);
+  line.appendChild(meta);
+  line.appendChild(toggleBtn);
+  line.appendChild(copyBtn);
 }
 
 function toCopyValue(value: unknown, type: string): string {


### PR DESCRIPTION
## Summary

- Parsed JSON tree abbreviates long string leaves (size + Show more/less + Copy), similar to Chrome Network
- en/zh i18n + PRIVACY note; unit tests for helpers
- Capture preview cap stays at 256KB

Closes #26

## Test plan

- [ ] `pnpm test && pnpm typecheck`
- [ ] Open Request → Payload → Parsed on a stream with long string fields; confirm Show more / Copy
- [ ] Events drawer JSON tree behaves the same
- [ ] Short strings unchanged
