### PR TITLE
chore: release 1.2.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ A clear description of what went wrong.
 
 - Chrome version:
 - OS:
-- Extension build: (commit SHA or `v1.2.0` / local `dist`)
+- Extension build: (commit SHA or `v1.2.1` / local `dist`)
 
 ## Steps to reproduce
 
@@ -27,8 +27,8 @@ A clear description of what went wrong.
 
 ## Does the local demo reproduce it?
 
-- [ ] Yes (`pnpm demo` â†’ http://127.0.0.1:8765)
-- [ ] No (only on site: â€¦)
+- [ ] Yes (`pnpm demo` â†?http://127.0.0.1:8765)
+- [ ] No (only on site: â€?
 - [ ] Not tried
 
 ## Extra

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extName__",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "__MSG_extDescription__",
   "icons": {
     "16": "icons/icon-16.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sse-devtools-panel",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "license": "MIT",
   "description": "Chrome DevTools panel for debugging SSE / NDJSON / Connect+JSON streaming responses",

--- a/src/panel/panel.ts
+++ b/src/panel/panel.ts
@@ -1035,7 +1035,7 @@ function refreshLocaleUi(): void {
   applyDomI18n();
   setUiPaused(state.uiPaused, pauseHooks);
   if (elStatusbarLocale) {
-    const version = chrome.runtime.getManifest?.().version ?? "1.2.0";
+    const version = chrome.runtime.getManifest?.().version ?? "1.2.1";
     elStatusbarLocale.textContent =
       getActiveLocale() === "zh_CN" ? `中文 · ${version}` : `EN · ${version}`;
   }


### PR DESCRIPTION
## Summary

Bump extension version to **1.2.1** after merging Network-style JSON string preview (#27, closes #26).

## Changes

- `package.json` / `manifest.json` → 1.2.1
- Status bar fallback version string
- Bug report template default tag

## Checklist

- [x] Version strings updated consistently
- [ ] CI green on this PR

## After merge

- Tag `v1.2.1`
- Create GitHub Release
- Upload zip to Chrome Web Store (badge chase)
