### PR TITLE
polish(website): refine nav CTA hierarchy and hero copy

### DIFF
--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -16,7 +16,7 @@ const t = getTranslations(locale);
   <h1 id="hero-title">{t.hero.title}</h1>
   <p class="lead">{t.hero.lead}</p>
   <div class="actions">
-    <a class="button primary" href="#install">{t.hero.ctaInstall}</a>
+    <a class="button primary" href="#demo">{t.hero.ctaDemo}</a>
     <a class="button" href={site.urls.github} target="_blank" rel="noreferrer">GitHub</a>
   </div>
   <ul class="proof" aria-label={t.hero.proofLabel}>

--- a/website/src/components/HeroDemo.astro
+++ b/website/src/components/HeroDemo.astro
@@ -11,7 +11,7 @@ const t = getTranslations(locale);
 const src = screenshotUrl("panel-overview.gif", import.meta.env.BASE_URL);
 ---
 
-<section class="hero-demo" aria-label={t.heroDemo.ariaLabel}>
+<section class="hero-demo" id="demo" aria-label={t.heroDemo.ariaLabel}>
   <div class="hero-demo-wrap">
     <div class="browser-frame">
       <div class="window-chrome">

--- a/website/src/components/SiteNav.astro
+++ b/website/src/components/SiteNav.astro
@@ -18,20 +18,29 @@ const langHref = switchLocalePath(locale, import.meta.env.BASE_URL);
     <span class="brand-name">{site.name}</span>
   </a>
   <div class="nav-actions">
-    <a href="#features">{t.nav.features}</a>
-    <a class="lang-switch" href={langHref} lang={locale === "zh" ? "en" : "zh-CN"} hreflang={locale === "zh" ? "en" : "zh-CN"}>
-      {t.nav.switchLang}
-    </a>
-    <a href={site.urls.github} target="_blank" rel="noreferrer">GitHub</a>
-    <button
-      class="theme-toggle"
-      type="button"
-      id="theme-toggle"
-      data-label-dark={t.nav.themeDark}
-      data-label-light={t.nav.themeLight}
-    >
-      {t.nav.themeDark}
-    </button>
+    <div class="nav-links">
+      <a href="#features">{t.nav.features}</a>
+      <a class="nav-github" href={site.urls.github} target="_blank" rel="noreferrer">GitHub</a>
+    </div>
+    <div class="nav-util">
+      <a
+        class="lang-switch"
+        href={langHref}
+        lang={locale === "zh" ? "en" : "zh-CN"}
+        hreflang={locale === "zh" ? "en" : "zh-CN"}
+      >
+        {t.nav.switchLang}
+      </a>
+      <button
+        class="theme-toggle"
+        type="button"
+        id="theme-toggle"
+        data-label-dark={t.nav.themeDark}
+        data-label-light={t.nav.themeLight}
+      >
+        {t.nav.themeDark}
+      </button>
+    </div>
     <a class="install-mini" href="#install">{t.nav.install}</a>
   </div>
 </nav>

--- a/website/src/i18n/en.ts
+++ b/website/src/i18n/en.ts
@@ -14,9 +14,9 @@ export const en: UI = {
   },
   hero: {
     eyebrow: "Chrome DevTools · SSE / NDJSON",
-    title: "Stop guessing streaming responses from raw fragments",
-    lead: "Inspect events, conversation, and timeline right in F12. Supports fetch / EventSource / XHR and common AI web protocols.",
-    ctaInstall: "Get extension",
+    title: "Understand SSE streams in DevTools",
+    lead: "Leave raw fragments behind—capture SSE / NDJSON from the page, parse and visualize in one panel.",
+    ctaDemo: "See demo",
     proofLabel: "Product highlights",
     proofOpenSource: "open source",
     proofLocal: "local processing",

--- a/website/src/i18n/types.ts
+++ b/website/src/i18n/types.ts
@@ -19,7 +19,7 @@ export interface UI {
     eyebrow: string;
     title: string;
     lead: string;
-    ctaInstall: string;
+    ctaDemo: string;
     proofLabel: string;
     proofOpenSource: string;
     proofLocal: string;

--- a/website/src/i18n/zh.ts
+++ b/website/src/i18n/zh.ts
@@ -14,9 +14,9 @@ export const zh: UI = {
   },
   hero: {
     eyebrow: "Chrome DevTools · SSE / NDJSON",
-    title: "别再对着原始碎片猜流式响应了",
-    lead: "在 F12 里直接看事件、对话与时间线。支持 fetch / EventSource / XHR，以及常见 AI 网页协议。",
-    ctaInstall: "获取扩展",
+    title: "在 DevTools 里看懂 SSE 流",
+    lead: "告别流式碎片，自动捕获网页 SSE / NDJSON 流——解析、可视化，一个面板全看清。",
+    ctaDemo: "查看演示",
     proofLabel: "产品要点",
     proofOpenSource: "开源",
     proofLocal: "处理，不上云",

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -94,25 +94,6 @@ button,
   cursor: pointer;
 }
 
-.lang-switch {
-  padding: 6px 10px;
-  color: var(--text-soft);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  font-size: 13px;
-  font-weight: 600;
-  transition:
-    color 0.2s ease,
-    border-color 0.2s ease,
-    background 0.2s ease;
-}
-
-.lang-switch:hover {
-  color: var(--text);
-  background: var(--surface);
-  border-color: var(--line-strong);
-}
-
 code {
   padding: 1px 5px;
   background: var(--surface);
@@ -179,17 +160,49 @@ code {
 .nav-actions {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 10px;
   font-size: 13px;
 }
 
-.nav-actions > a:not(.install-mini) {
+.nav-links,
+.nav-util {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.nav-links > a,
+.nav-util .lang-switch {
   color: var(--muted);
   transition: color 0.2s ease;
 }
 
-.nav-actions > a:not(.install-mini):hover {
+.nav-links > a:hover,
+.nav-util .lang-switch:hover {
   color: var(--text);
+}
+
+.nav-util {
+  padding: 0 10px;
+  border-left: 1px solid var(--line);
+  border-right: 1px solid var(--line);
+}
+
+.lang-switch {
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease,
+    background 0.2s ease;
+}
+
+.lang-switch:hover {
+  background: var(--surface);
+  border-color: var(--line-strong);
 }
 
 .theme-toggle,
@@ -199,24 +212,35 @@ code {
   justify-content: center;
   min-height: 36px;
   padding: 0 12px;
-  color: var(--text);
-  background: var(--surface);
-  border: 1px solid var(--line);
   border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
   transition:
     background 0.2s ease,
-    border-color 0.2s ease;
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
-.theme-toggle:hover,
-.install-mini:hover {
+.theme-toggle {
+  color: var(--text-soft);
+  background: var(--surface);
+  border: 1px solid var(--line);
+}
+
+.theme-toggle:hover {
   border-color: var(--line-strong);
 }
 
 .install-mini {
   color: #fff;
-  background: var(--btn-dark);
-  border-color: var(--btn-dark);
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  box-shadow: 0 4px 14px rgba(37, 99, 235, 0.22);
+}
+
+.install-mini:hover {
+  background: var(--blue);
+  border-color: var(--blue);
 }
 
 .theme-toggle:focus-visible,
@@ -249,6 +273,7 @@ code {
   font-weight: 800;
   line-height: 1.12;
   letter-spacing: -0.045em;
+  white-space: nowrap;
 }
 
 .lead {
@@ -904,8 +929,23 @@ code {
     order: unset;
   }
 
-  .nav-actions > a:not(.install-mini):not([href="#features"]):not(.lang-switch) {
+  .nav-links .nav-github {
     display: none;
+  }
+
+  .nav-util {
+    padding: 0 8px;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero-focus h1 {
+    white-space: normal;
+  }
+
+  .nav-util {
+    border-left: 0;
+    padding-left: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- Reorder nav: Features/GitHub | EN/Theme | blue Get Extension
- Hero primary CTA is See Demo; install kept in nav + bottom section
- Update zh/en hero title and lead copy

## Test plan
- [ ] CI green
- [ ] After merge: Deploy Website updates https://fatmii.github.io/sse-devtools-panel/
- [ ] Check nav layout, blue install CTA, hero copy on / and /en/