### PR TITLE
feat: add ACP Conversation vendor profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Conversation merges content by protocol profile. Currently supported:
 | `qwen-web`          | Qwen web                | Plan thinking / deep thinking / search             |
 | `chatglm-web`       | ChatGLM / Zhipu Qingyan | Thinking / content / search results                |
 | `yuanbao-web`       | Tencent Yuanbao         | Deep-search thinking + sources                     |
+| `acp`               | ACP-over-HTTP SSE       | `session/update` → content / thinking / tools      |
 | `anthropic`         | Anthropic-style SSE     | Profile detection only — no Conversation merge yet |
 | `generic`           | Unrecognized            | Events / Timeline / Raw still work                 |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -331,17 +331,18 @@ Events、对话（正文 / 思考）、Raw 都用了虚拟滚动：屏幕外的�
 
 对话视图会按协议类型合并内容。当前已适配：
 
-| Profile             | 典型站点 / 形态      | 说明                           |
-| ------------------- | -------------------- | ------------------------------ |
-| `openai-compatible` | 各类 OpenAI 兼容 API | 正文 / 思考 / 工具调用         |
-| `deepseek-web`      | DeepSeek 网页        | 思考 + 正文；支持搜索工具      |
-| `doubao-web`        | 豆包网页             | 思考与正文拆分；搜索结果去重   |
-| `kimi-web`          | Kimi                 | 思考 / 正文 / 搜索             |
-| `qwen-web`          | 通义千问网页         | 计划思考 / 深度思考 / 搜索     |
-| `chatglm-web`       | 智谱清言 / ChatGLM   | 思考 / 正文 / 搜索结果         |
-| `yuanbao-web`       | 腾讯元宝             | 深度搜索思考 + 来源            |
-| `anthropic`         | Anthropic 风格 SSE   | 仅协议识别 — 对话合并尚未实现  |
-| `generic`           | 未识别               | 仍可看 Events / Timeline / Raw |
+| Profile             | 典型站点 / 形态      | 说明                                  |
+| ------------------- | -------------------- | ------------------------------------- |
+| `openai-compatible` | 各类 OpenAI 兼容 API | 正文 / 思考 / 工具调用                |
+| `deepseek-web`      | DeepSeek 网页        | 思考 + 正文；支持搜索工具             |
+| `doubao-web`        | 豆包网页             | 思考与正文拆分；搜索结果去重          |
+| `kimi-web`          | Kimi                 | 思考 / 正文 / 搜索                    |
+| `qwen-web`          | 通义千问网页         | 计划思考 / 深度思考 / 搜索            |
+| `chatglm-web`       | 智谱清言 / ChatGLM   | 思考 / 正文 / 搜索结果                |
+| `yuanbao-web`       | 腾讯元宝             | 深度搜索思考 + 来源                   |
+| `acp`               | ACP-over-HTTP SSE    | `session/update` → 内容 / 思考 / 工具 |
+| `anthropic`         | Anthropic 风格 SSE   | 仅协议识别 — 对话合并尚未实现         |
+| `generic`           | 未识别               | 仍可看 Events / Timeline / Raw        |
 
 > 各站协议常变。若对话视图为空或工具卡不对，请导出 Raw 或 JSON 并注明 URL。  
 > 未列出的站点：有真实样本后再适配。  

--- a/fixtures/vendors/acp/events.json
+++ b/fixtures/vendors/acp/events.json
@@ -1,0 +1,42 @@
+[
+  {
+    "event": "snapshot",
+    "data": "{\"sessionId\": \"s1\", \"version\": 0, \"epoch\": 1, \"updates\": []}"
+  },
+  {
+    "event": "update",
+    "data": "[{\"jsonrpc\": \"2.0\", \"method\": \"session/update\", \"params\": {\"sessionId\": \"s1\", \"update\": {\"sessionUpdate\": \"plan\", \"entries\": [{\"content\": \"read the file\", \"status\": \"pending\", \"priority\": \"high\"}, {\"content\": \"reply\", \"status\": \"pending\"}]}}}]"
+  },
+  {
+    "event": "update",
+    "data": "[{\"jsonrpc\": \"2.0\", \"method\": \"session/update\", \"params\": {\"sessionId\": \"s1\", \"update\": {\"sessionUpdate\": \"agent_thought_chunk\", \"messageId\": \"m-thought\", \"content\": {\"type\": \"text\", \"text\": \"plan the reply\"}}}}]"
+  },
+  {
+    "event": "update",
+    "data": "[{\"jsonrpc\": \"2.0\", \"method\": \"session/update\", \"params\": {\"sessionId\": \"s1\", \"update\": {\"sessionUpdate\": \"agent_message_chunk\", \"messageId\": \"m1\", \"content\": {\"type\": \"text\", \"text\": \"Hello \"}}}}]"
+  },
+  {
+    "event": "update",
+    "data": "[{\"jsonrpc\": \"2.0\", \"method\": \"session/update\", \"params\": {\"sessionId\": \"s1\", \"update\": {\"sessionUpdate\": \"agent_message_chunk\", \"messageId\": \"m1\", \"content\": {\"type\": \"text\", \"text\": \"from ACP\"}}}}]"
+  },
+  {
+    "event": "update",
+    "data": "[{\"jsonrpc\": \"2.0\", \"method\": \"session/update\", \"params\": {\"sessionId\": \"s1\", \"update\": {\"sessionUpdate\": \"tool_call\", \"toolCallId\": \"t1\", \"title\": \"Read\", \"status\": \"pending\", \"rawInput\": {\"path\": \"/tmp/a.ts\"}}}}]"
+  },
+  {
+    "event": "update",
+    "data": "[{\"jsonrpc\": \"2.0\", \"method\": \"session/update\", \"params\": {\"sessionId\": \"s1\", \"update\": {\"sessionUpdate\": \"tool_call_update\", \"toolCallId\": \"t1\", \"status\": \"completed\", \"rawOutput\": {\"ok\": true}}}}]"
+  },
+  {
+    "event": "update",
+    "data": "[{\"jsonrpc\": \"2.0\", \"method\": \"session/update\", \"params\": {\"sessionId\": \"s1\", \"update\": {\"sessionUpdate\": \"usage_update\", \"used\": 1200, \"size\": 8000}}}]"
+  },
+  {
+    "event": "update",
+    "data": "[{\"jsonrpc\": \"2.0\", \"method\": \"session/update\", \"params\": {\"sessionId\": \"s1\", \"update\": {\"sessionUpdate\": \"state_update\", \"state\": \"idle\", \"stopReason\": \"end_turn\"}}}]"
+  },
+  {
+    "event": "stream-alive",
+    "data": "{\"jsonrpc\": \"2.0\", \"method\": \"_drive/streamAlive\", \"params\": {}}"
+  }
+]

--- a/fixtures/vendors/acp/expect.json
+++ b/fixtures/vendors/acp/expect.json
@@ -1,0 +1,11 @@
+{
+  "url": "http://127.0.0.1:4004/api/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/events",
+  "profile": "acp",
+  "vendorHint": "acp",
+  "reasoningIncludes": ["plan the reply", "[plan]", "read the file", "reply"],
+  "contentIncludes": ["Hello ", "from ACP"],
+  "contentExcludes": ["plan the reply", "[plan]"],
+  "minTools": 1,
+  "toolName": "Read",
+  "finishReason": "end_turn"
+}

--- a/fixtures/vendors/acp/expect.json
+++ b/fixtures/vendors/acp/expect.json
@@ -1,5 +1,5 @@
 {
-  "url": "http://127.0.0.1:4004/api/agents/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/events",
+  "url": "https://example.test/any-stream",
   "profile": "acp",
   "vendorHint": "acp",
   "reasoningIncludes": ["plan the reply", "[plan]", "read the file", "reply"],

--- a/src/shared/ai-merge/__tests__/acp.test.ts
+++ b/src/shared/ai-merge/__tests__/acp.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { detectAiProfile, isAcpProtocolPayload } from "../../ai-profile";
+import { conversationHasContent, mergeAiConversation } from "../index";
+
+describe("acp snapshot-only streams", () => {
+  it("treats SessionUpdates inside updates[] as protocol payloads", () => {
+    expect(
+      isAcpProtocolPayload({
+        sessionId: "s1",
+        version: 3,
+        updates: [
+          {
+            sessionUpdate: "agent_thought",
+            messageId: "t1",
+            content: [{ type: "text", text: "thinking" }],
+          },
+        ],
+      }),
+    ).toBe(true);
+
+    expect(
+      isAcpProtocolPayload({
+        sessionId: "s1",
+        version: 0,
+        updates: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("detects and merges a snapshot-only conversation (no JSON-RPC update frames)", () => {
+    const events = [
+      {
+        event: "snapshot",
+        data: JSON.stringify({
+          sessionId: "s1",
+          version: 2,
+          updates: [
+            {
+              sessionUpdate: "agent_thought",
+              messageId: "th1",
+              content: [{ type: "text", text: "only thought" }],
+            },
+            {
+              sessionUpdate: "agent_message",
+              messageId: "m1",
+              content: [{ type: "text", text: "only message" }],
+            },
+          ],
+        }),
+      },
+    ];
+
+    const det = detectAiProfile(events, "https://example.test/whatever");
+    expect(det.profile).toBe("acp");
+    expect(det.vendorHint).toBe("acp");
+
+    const merged = mergeAiConversation(events, "https://example.test/whatever");
+    expect(merged.profile).toBe("acp");
+    expect(merged.channels.reasoning).toContain("only thought");
+    expect(merged.channels.content).toContain("only message");
+    expect(merged.channels.content).not.toContain("only thought");
+    expect(merged.channels.reasoning).not.toContain("only message");
+    expect(conversationHasContent(merged)).toBe(true);
+  });
+});

--- a/src/shared/ai-merge/__tests__/vendor-fixtures.test.ts
+++ b/src/shared/ai-merge/__tests__/vendor-fixtures.test.ts
@@ -7,7 +7,15 @@ import { conversationHasContent, mergeAiConversation } from "../index";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../");
 const vendorsRoot = resolve(repoRoot, "fixtures/vendors");
 
-const REQUIRED_VENDORS = ["deepseek", "doubao", "kimi", "qwen", "chatglm", "yuanbao"] as const;
+const REQUIRED_VENDORS = [
+  "deepseek",
+  "doubao",
+  "kimi",
+  "qwen",
+  "chatglm",
+  "yuanbao",
+  "acp",
+] as const;
 
 type FixtureEvent = { data: string; event?: string };
 

--- a/src/shared/ai-merge/acp.ts
+++ b/src/shared/ai-merge/acp.ts
@@ -1,0 +1,279 @@
+import type { SseEvent } from "../types";
+import { isAcpWireChunk } from "../ai-profile";
+import type { AiEndMeta, AiToolCall, MergeChannelsResult } from "./types";
+import { asString, isRecord, parseEventData } from "./helpers";
+
+export type AcpToolPayload = {
+  input?: unknown;
+  status?: string;
+  output?: unknown;
+};
+
+export type AcpMergeState = {
+  content: string;
+  /** Agent thought chunks only (plan is tracked separately). */
+  reasoning: string;
+  /** Latest rendered plan block (replaced on each plan snapshot). */
+  planText: string;
+  tools: Map<string, AiToolCall>;
+  /** Parallel structured tool fields (merged into `arguments` on snapshot). */
+  toolPayloads: Map<string, AcpToolPayload>;
+  endMeta: AiEndMeta;
+  chunkCount: number;
+};
+
+const CONTENT_KINDS = new Set(["agent_message_chunk", "agent_message"]);
+
+const THOUGHT_KINDS = new Set(["agent_thought_chunk", "agent_thought"]);
+
+const TOOL_KINDS = new Set(["tool_call", "tool_call_update"]);
+
+const PLAN_KINDS = new Set(["plan", "plan_update"]);
+
+export function createAcpMergeState(): AcpMergeState {
+  return {
+    content: "",
+    reasoning: "",
+    planText: "",
+    tools: new Map(),
+    toolPayloads: new Map(),
+    endMeta: {},
+    chunkCount: 0,
+  };
+}
+
+/** Extract plain text from an ACP ContentBlock, block array, or string. */
+export function extractAcpText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value.map(extractAcpText).filter(Boolean).join("");
+  }
+  if (!isRecord(value)) return "";
+  if (value.type === "text" && typeof value.text === "string") return value.text;
+  // Some agents nest text under `content` on a block.
+  if ("text" in value && typeof value.text === "string" && value.type == null) {
+    return value.text;
+  }
+  return "";
+}
+
+function formatPlanEntries(entries: unknown): string {
+  if (!Array.isArray(entries) || entries.length === 0) return "";
+  const lines: string[] = ["[plan]"];
+  for (const entry of entries) {
+    if (!isRecord(entry)) continue;
+    const content = asString(entry.content) ?? "";
+    if (!content) continue;
+    const status = asString(entry.status);
+    const priority = asString(entry.priority);
+    const bits = [status, priority].filter(Boolean).join("/");
+    lines.push(bits ? `- [${bits}] ${content}` : `- ${content}`);
+  }
+  return lines.length > 1 ? lines.join("\n") : "";
+}
+
+/** Render plan / plan_update into a Thinking-friendly text block. */
+export function formatAcpPlan(update: Record<string, unknown>): string {
+  const kind = asString(update.sessionUpdate);
+  if (kind === "plan") {
+    return formatPlanEntries(update.entries);
+  }
+  if (kind === "plan_update" && isRecord(update.plan)) {
+    const plan = update.plan;
+    const id = asString(plan.planId);
+    const body = formatPlanEntries(plan.entries);
+    if (!body) return "";
+    return id ? body.replace("[plan]", `[plan ${id}]`) : body;
+  }
+  return "";
+}
+
+function collectUpdates(parsed: unknown): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [];
+
+  const pushUpdate = (u: unknown) => {
+    if (isRecord(u) && typeof u.sessionUpdate === "string") out.push(u);
+  };
+
+  if (Array.isArray(parsed)) {
+    for (const item of parsed) {
+      if (!isRecord(item)) continue;
+      // JSON-RPC batch: { jsonrpc, method: "session/update", params: { update } }
+      if (item.method === "session/update" && isRecord(item.params)) {
+        pushUpdate(item.params.update);
+        continue;
+      }
+      pushUpdate(item);
+    }
+    return out;
+  }
+
+  if (!isRecord(parsed)) return out;
+
+  // Session snapshot frame: { sessionId, version, updates: [...] }
+  if (Array.isArray(parsed.updates)) {
+    for (const u of parsed.updates) pushUpdate(u);
+    return out;
+  }
+
+  // Single JSON-RPC notification
+  if (parsed.method === "session/update" && isRecord(parsed.params)) {
+    pushUpdate(parsed.params.update);
+    return out;
+  }
+
+  // Bare session update object
+  pushUpdate(parsed);
+  return out;
+}
+
+function syncToolArguments(state: AcpMergeState, id: string): void {
+  const slot = state.tools.get(id);
+  const payload = state.toolPayloads.get(id);
+  if (!slot || !payload) return;
+  const hasExtra =
+    payload.status !== undefined || payload.output !== undefined || payload.input !== undefined;
+  if (!hasExtra) {
+    slot.arguments = "";
+    return;
+  }
+  // Prefer a stable JSON object so Tools cards show status/output, not only rawInput.
+  slot.arguments = JSON.stringify(payload);
+}
+
+function applyUpdate(state: AcpMergeState, update: Record<string, unknown>): void {
+  const kind = asString(update.sessionUpdate);
+  if (!kind) return;
+
+  // Ignore control / meta surfaces — Conversation is chat-facing only.
+  if (kind.startsWith("_drive/")) return;
+  if (
+    kind === "session_info_update" ||
+    kind === "available_commands_update" ||
+    kind === "config_option_update" ||
+    kind === "current_mode_update" ||
+    kind === "user_message_chunk" ||
+    kind === "user_message" ||
+    kind === "plan_removed"
+  ) {
+    if (kind === "plan_removed") state.planText = "";
+    return;
+  }
+
+  if (kind === "state_update") {
+    const stop = asString(update.stopReason);
+    const stateName = asString(update.state);
+    // Turn finished: idle + stopReason is the canonical ACP end signal on this wire.
+    if (stateName === "idle" && stop) {
+      state.endMeta.finishReason = stop;
+      state.chunkCount++;
+    }
+    return;
+  }
+
+  if (kind === "usage_update") {
+    const usage: Record<string, unknown> = {};
+    if (typeof update.used === "number") usage.used = update.used;
+    if (typeof update.size === "number") usage.size = update.size;
+    if (update.cost !== undefined) usage.cost = update.cost;
+    if (Object.keys(usage).length > 0) {
+      state.endMeta.usage = usage;
+      state.chunkCount++;
+    }
+    return;
+  }
+
+  if (PLAN_KINDS.has(kind)) {
+    const rendered = formatAcpPlan(update);
+    if (rendered) {
+      state.planText = rendered;
+      state.chunkCount++;
+    }
+    return;
+  }
+
+  if (CONTENT_KINDS.has(kind)) {
+    const text = extractAcpText(update.content);
+    if (text) {
+      state.content += text;
+      state.chunkCount++;
+    }
+    return;
+  }
+
+  if (THOUGHT_KINDS.has(kind)) {
+    const text = extractAcpText(update.content);
+    if (text) {
+      state.reasoning += text;
+      state.chunkCount++;
+    }
+    return;
+  }
+
+  if (TOOL_KINDS.has(kind)) {
+    const id = asString(update.toolCallId) ?? `tool-${state.tools.size}`;
+    let slot = state.tools.get(id);
+    if (!slot) {
+      slot = { index: state.tools.size, id, arguments: "" };
+      state.tools.set(id, slot);
+    }
+    let payload = state.toolPayloads.get(id);
+    if (!payload) {
+      payload = {};
+      state.toolPayloads.set(id, payload);
+    }
+
+    const name = asString(update.title) ?? asString(update.name);
+    if (name) slot.name = name;
+    if (update.rawInput !== undefined) payload.input = update.rawInput;
+    const status = asString(update.status);
+    if (status) payload.status = status;
+    if (update.rawOutput !== undefined) payload.output = update.rawOutput;
+
+    syncToolArguments(state, id);
+    state.chunkCount++;
+  }
+}
+
+export function pushAcp(
+  state: AcpMergeState,
+  events: ReadonlyArray<Pick<SseEvent, "data" | "event">>,
+): void {
+  for (const ev of events) {
+    // Control frames carry no conversation payload.
+    if (ev.event === "stream-alive" || ev.event === "taken-over") continue;
+
+    const parsed = parseEventData(ev.data);
+    if (parsed == null) continue;
+    if (!isAcpWireChunk(parsed, ev.event)) continue;
+
+    for (const update of collectUpdates(parsed)) {
+      applyUpdate(state, update);
+    }
+  }
+}
+
+function combinedReasoning(state: AcpMergeState): string {
+  if (state.reasoning && state.planText) return `${state.reasoning}\n\n${state.planText}`;
+  return state.reasoning || state.planText;
+}
+
+export function snapshotAcp(state: AcpMergeState): MergeChannelsResult {
+  return {
+    channels: {
+      content: state.content,
+      reasoning: combinedReasoning(state),
+      tools: Array.from(state.tools.values()).sort((a, b) => a.index - b.index),
+    },
+    endMeta: state.endMeta,
+    chunkCount: state.chunkCount,
+  };
+}
+
+export function mergeAcp(
+  events: ReadonlyArray<Pick<SseEvent, "data" | "event">>,
+): MergeChannelsResult {
+  const s = createAcpMergeState();
+  pushAcp(s, events);
+  return snapshotAcp(s);
+}

--- a/src/shared/ai-merge/index.ts
+++ b/src/shared/ai-merge/index.ts
@@ -68,6 +68,9 @@ export {
   mergeYuanbaoWeb,
 } from "./yuanbao";
 
+export type { AcpMergeState } from "./acp";
+export { createAcpMergeState, pushAcp, snapshotAcp, mergeAcp, extractAcpText } from "./acp";
+
 export {
   ConversationMergeSession,
   getConversationMergeSession,

--- a/src/shared/ai-merge/session.ts
+++ b/src/shared/ai-merge/session.ts
@@ -43,6 +43,7 @@ import {
   snapshotYuanbaoWeb,
   type YuanbaoWebMergeState,
 } from "./yuanbao";
+import { createAcpMergeState, pushAcp, snapshotAcp, type AcpMergeState } from "./acp";
 
 type EventLike = Pick<SseEvent, "data" | "event">;
 
@@ -53,7 +54,8 @@ type VendorState =
   | { profile: "kimi-web"; state: KimiWebMergeState }
   | { profile: "qwen-web"; state: QwenWebMergeState }
   | { profile: "chatglm-web"; state: ChatglmWebMergeState }
-  | { profile: "yuanbao-web"; state: YuanbaoWebMergeState };
+  | { profile: "yuanbao-web"; state: YuanbaoWebMergeState }
+  | { profile: "acp"; state: AcpMergeState };
 
 function emptyChannelsResult(): MergeChannelsResult {
   return {
@@ -79,6 +81,8 @@ function createVendor(profile: AiProfile): VendorState | null {
       return { profile, state: createChatglmWebMergeState() };
     case "yuanbao-web":
       return { profile, state: createYuanbaoWebMergeState() };
+    case "acp":
+      return { profile, state: createAcpMergeState() };
     default:
       return null;
   }
@@ -107,6 +111,9 @@ function pushVendor(vendor: VendorState, events: ReadonlyArray<EventLike>): void
     case "yuanbao-web":
       pushYuanbaoWeb(vendor.state, events);
       break;
+    case "acp":
+      pushAcp(vendor.state, events);
+      break;
   }
 }
 
@@ -127,6 +134,8 @@ function snapshotVendor(vendor: VendorState | null): MergeChannelsResult {
       return snapshotChatglmWeb(vendor.state);
     case "yuanbao-web":
       return snapshotYuanbaoWeb(vendor.state);
+    case "acp":
+      return snapshotAcp(vendor.state);
   }
 }
 

--- a/src/shared/ai-profile.ts
+++ b/src/shared/ai-profile.ts
@@ -9,6 +9,7 @@ export type AiProfile =
   | "qwen-web"
   | "chatglm-web"
   | "yuanbao-web"
+  | "acp"
   | "anthropic"
   | "generic";
 
@@ -24,6 +25,7 @@ export type AiVendorHint =
   | "baichuan"
   | "openai"
   | "anthropic"
+  | "acp"
   | "unknown";
 
 export interface AiProfileResult {
@@ -87,6 +89,11 @@ const VENDOR_HOST_RULES: Array<{ hint: AiVendorHint; test: (host: string) => boo
   { hint: "anthropic", test: (h) => h.includes("anthropic.com") || h.includes("claude") },
 ];
 
+/** Common ACP-over-HTTP session SSE path: GET …/api/agents/:id/events */
+const ACP_EVENTS_PATH = /\/api\/agents\/[^/]+\/events(?:\?|$)/i;
+
+const ACP_SSE_EVENTS = new Set(["snapshot", "update", "stream-alive", "taken-over"]);
+
 const DOUBAO_WEB_EVENTS = new Set([
   "SSE_HEARTBEAT",
   "SSE_ACK",
@@ -116,10 +123,17 @@ const KIMI_GENERIC_EVENT_NAMES = new Set(["message", "delta"]);
 export function vendorHintFromUrl(url: string | undefined): AiVendorHint {
   if (!url) return "unknown";
   let host: string;
+  let pathWithQuery: string;
   try {
-    host = new URL(url, "https://dummy.local").hostname.toLowerCase();
+    const u = new URL(url, "https://dummy.local");
+    host = u.hostname.toLowerCase();
+    pathWithQuery = `${u.pathname}${u.search}`;
   } catch {
     host = url.toLowerCase();
+    pathWithQuery = url;
+  }
+  if (ACP_EVENTS_PATH.test(pathWithQuery) || ACP_EVENTS_PATH.test(url)) {
+    return "acp";
   }
   for (const rule of VENDOR_HOST_RULES) {
     if (rule.test(host)) return rule.hint;
@@ -315,6 +329,60 @@ function isAnthropicChunk(value: unknown): boolean {
   );
 }
 
+function isAcpSessionUpdate(value: unknown): boolean {
+  return isRecord(value) && typeof value.sessionUpdate === "string";
+}
+
+function isAcpJsonRpcSessionUpdate(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    value.jsonrpc === "2.0" &&
+    value.method === "session/update" &&
+    isRecord(value.params) &&
+    isAcpSessionUpdate(value.params.update)
+  );
+}
+
+/**
+ * Agent Client Protocol (ACP) over HTTP session SSE.
+ *
+ * Shapes:
+ * - `event: update` → JSON-RPC batch of `session/update` notifications
+ * - `event: snapshot` → `{ sessionId, version, updates: SessionUpdate[] }`
+ * - bare JSON-RPC `session/update` (single or batch)
+ */
+export function isAcpWireChunk(value: unknown, eventName?: string): boolean {
+  if (eventName === "snapshot") {
+    return (
+      isRecord(value) && Array.isArray(value.updates) && value.updates.some(isAcpSessionUpdate)
+    );
+  }
+  if (eventName === "update") {
+    return Array.isArray(value) && value.some(isAcpJsonRpcSessionUpdate);
+  }
+  // stream-alive / taken-over are ACP session-SSE control frames but carry no chat payload.
+  if (
+    eventName &&
+    ACP_SSE_EVENTS.has(eventName) &&
+    eventName !== "snapshot" &&
+    eventName !== "update"
+  ) {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => isAcpJsonRpcSessionUpdate(item) || isAcpSessionUpdate(item));
+  }
+
+  if (isAcpJsonRpcSessionUpdate(value)) return true;
+
+  if (isRecord(value) && Array.isArray(value.updates)) {
+    return value.updates.some(isAcpSessionUpdate);
+  }
+
+  return isAcpSessionUpdate(value);
+}
+
 function collectReasoningFields(value: unknown, into: Set<string>): void {
   if (!isRecord(value)) return;
   if (Array.isArray(value.choices)) {
@@ -359,6 +427,7 @@ export function detectAiProfile(
   let chatglmHits = 0;
   let yuanbaoHits = 0;
   let anthropicHits = 0;
+  let acpHits = 0;
   const sampleLimit = Math.min(events.length, 80);
 
   for (let i = 0; i < sampleLimit; i++) {
@@ -373,6 +442,7 @@ export function detectAiProfile(
       kimiHits += 2;
     }
     if (ev.event === "speech_type") yuanbaoHits += 2;
+    if (ev.event === "snapshot" || ev.event === "update") acpHits += 2;
 
     const parsed = tryParseJson(ev.data);
     if (parsed == null) continue;
@@ -404,6 +474,10 @@ export function detectAiProfile(
       yuanbaoHits++;
       reasoningFields.add("deepSearch");
     }
+    if (isAcpWireChunk(parsed, ev.event)) {
+      acpHits++;
+      reasoningFields.add("session/update");
+    }
     if (
       isAnthropicChunk(parsed) ||
       ev.event.startsWith("content_block") ||
@@ -421,6 +495,7 @@ export function detectAiProfile(
     { profile: "qwen-web", score: qwenHits },
     { profile: "chatglm-web", score: chatglmHits },
     { profile: "yuanbao-web", score: yuanbaoHits },
+    { profile: "acp", score: acpHits },
     { profile: "anthropic", score: anthropicHits },
   ];
   scores.sort((a, b) => b.score - a.score);
@@ -448,6 +523,11 @@ export function detectAiProfile(
     profile = "yuanbao-web";
   }
 
+  // Prefer ACP when URL or payload looks like session SSE with session/update.
+  if (vendorHint === "acp" && acpHits >= 1 && acpHits >= openaiHits) {
+    profile = "acp";
+  }
+
   let resolvedVendor = vendorHint;
   if (profile === "deepseek-web") resolvedVendor = "deepseek";
   else if (profile === "doubao-web") resolvedVendor = "doubao-web";
@@ -455,7 +535,9 @@ export function detectAiProfile(
   else if (profile === "qwen-web") resolvedVendor = "qwen";
   else if (profile === "chatglm-web") resolvedVendor = "chatglm";
   else if (profile === "yuanbao-web") resolvedVendor = "yuanbao";
-  else if (
+  else if (profile === "acp") {
+    resolvedVendor = "acp";
+  } else if (
     profile === "openai-compatible" &&
     vendorHint === "unknown" &&
     reasoningFields.has("reasoning_content")

--- a/src/shared/ai-profile.ts
+++ b/src/shared/ai-profile.ts
@@ -332,29 +332,27 @@ function isAcpJsonRpcSessionUpdate(value: unknown): boolean {
 }
 
 /**
- * True ACP protocol payloads only (no URL / SSE event-name / proprietary envelopes):
+ * True ACP protocol payloads (no URL / SSE event-name heuristics):
  * - JSON-RPC notification `session/update` (single or batch)
  * - SessionUpdate object (`sessionUpdate` discriminator)
+ * - A list of SessionUpdates under `updates` (coalesced replay / snapshot *body* —
+ *   the SessionUpdates are protocol; an SSE event name like `snapshot` is not)
  */
 export function isAcpProtocolPayload(value: unknown): boolean {
   if (Array.isArray(value)) {
     return value.some((item) => isAcpJsonRpcSessionUpdate(item) || isAcpSessionUpdate(item));
   }
   if (isAcpJsonRpcSessionUpdate(value)) return true;
-  return isAcpSessionUpdate(value);
-}
-
-/**
- * Wire chunk that the ACP merger may consume.
- * Includes protocol payloads plus wrappers that embed SessionUpdate lists
- * (e.g. a snapshot frame with `updates: SessionUpdate[]`).
- */
-export function isAcpWireChunk(value: unknown, _eventName?: string): boolean {
-  if (isAcpProtocolPayload(value)) return true;
+  if (isAcpSessionUpdate(value)) return true;
   if (isRecord(value) && Array.isArray(value.updates)) {
     return value.updates.some(isAcpSessionUpdate);
   }
   return false;
+}
+
+/** Wire chunk the ACP merger may consume — same shapes as protocol detection. */
+export function isAcpWireChunk(value: unknown, _eventName?: string): boolean {
+  return isAcpProtocolPayload(value);
 }
 
 function collectReasoningFields(value: unknown, into: Set<string>): void {

--- a/src/shared/ai-profile.ts
+++ b/src/shared/ai-profile.ts
@@ -89,11 +89,6 @@ const VENDOR_HOST_RULES: Array<{ hint: AiVendorHint; test: (host: string) => boo
   { hint: "anthropic", test: (h) => h.includes("anthropic.com") || h.includes("claude") },
 ];
 
-/** Common ACP-over-HTTP session SSE path: GET …/api/agents/:id/events */
-const ACP_EVENTS_PATH = /\/api\/agents\/[^/]+\/events(?:\?|$)/i;
-
-const ACP_SSE_EVENTS = new Set(["snapshot", "update", "stream-alive", "taken-over"]);
-
 const DOUBAO_WEB_EVENTS = new Set([
   "SSE_HEARTBEAT",
   "SSE_ACK",
@@ -123,17 +118,10 @@ const KIMI_GENERIC_EVENT_NAMES = new Set(["message", "delta"]);
 export function vendorHintFromUrl(url: string | undefined): AiVendorHint {
   if (!url) return "unknown";
   let host: string;
-  let pathWithQuery: string;
   try {
-    const u = new URL(url, "https://dummy.local");
-    host = u.hostname.toLowerCase();
-    pathWithQuery = `${u.pathname}${u.search}`;
+    host = new URL(url, "https://dummy.local").hostname.toLowerCase();
   } catch {
     host = url.toLowerCase();
-    pathWithQuery = url;
-  }
-  if (ACP_EVENTS_PATH.test(pathWithQuery) || ACP_EVENTS_PATH.test(url)) {
-    return "acp";
   }
   for (const rule of VENDOR_HOST_RULES) {
     if (rule.test(host)) return rule.hint;
@@ -344,43 +332,29 @@ function isAcpJsonRpcSessionUpdate(value: unknown): boolean {
 }
 
 /**
- * Agent Client Protocol (ACP) over HTTP session SSE.
- *
- * Shapes:
- * - `event: update` → JSON-RPC batch of `session/update` notifications
- * - `event: snapshot` → `{ sessionId, version, updates: SessionUpdate[] }`
- * - bare JSON-RPC `session/update` (single or batch)
+ * True ACP protocol payloads only (no URL / SSE event-name / proprietary envelopes):
+ * - JSON-RPC notification `session/update` (single or batch)
+ * - SessionUpdate object (`sessionUpdate` discriminator)
  */
-export function isAcpWireChunk(value: unknown, eventName?: string): boolean {
-  if (eventName === "snapshot") {
-    return (
-      isRecord(value) && Array.isArray(value.updates) && value.updates.some(isAcpSessionUpdate)
-    );
-  }
-  if (eventName === "update") {
-    return Array.isArray(value) && value.some(isAcpJsonRpcSessionUpdate);
-  }
-  // stream-alive / taken-over are ACP session-SSE control frames but carry no chat payload.
-  if (
-    eventName &&
-    ACP_SSE_EVENTS.has(eventName) &&
-    eventName !== "snapshot" &&
-    eventName !== "update"
-  ) {
-    return false;
-  }
-
+export function isAcpProtocolPayload(value: unknown): boolean {
   if (Array.isArray(value)) {
     return value.some((item) => isAcpJsonRpcSessionUpdate(item) || isAcpSessionUpdate(item));
   }
-
   if (isAcpJsonRpcSessionUpdate(value)) return true;
+  return isAcpSessionUpdate(value);
+}
 
+/**
+ * Wire chunk that the ACP merger may consume.
+ * Includes protocol payloads plus wrappers that embed SessionUpdate lists
+ * (e.g. a snapshot frame with `updates: SessionUpdate[]`).
+ */
+export function isAcpWireChunk(value: unknown, _eventName?: string): boolean {
+  if (isAcpProtocolPayload(value)) return true;
   if (isRecord(value) && Array.isArray(value.updates)) {
     return value.updates.some(isAcpSessionUpdate);
   }
-
-  return isAcpSessionUpdate(value);
+  return false;
 }
 
 function collectReasoningFields(value: unknown, into: Set<string>): void {
@@ -442,7 +416,6 @@ export function detectAiProfile(
       kimiHits += 2;
     }
     if (ev.event === "speech_type") yuanbaoHits += 2;
-    if (ev.event === "snapshot" || ev.event === "update") acpHits += 2;
 
     const parsed = tryParseJson(ev.data);
     if (parsed == null) continue;
@@ -474,9 +447,9 @@ export function detectAiProfile(
       yuanbaoHits++;
       reasoningFields.add("deepSearch");
     }
-    if (isAcpWireChunk(parsed, ev.event)) {
+    if (isAcpProtocolPayload(parsed)) {
       acpHits++;
-      reasoningFields.add("session/update");
+      reasoningFields.add("sessionUpdate");
     }
     if (
       isAnthropicChunk(parsed) ||
@@ -521,11 +494,6 @@ export function detectAiProfile(
   // Prefer yuanbao-web on Yuanbao/Hunyuan hosts when deepSearch frames are present.
   if (vendorHint === "yuanbao" && yuanbaoHits >= 2 && yuanbaoHits >= openaiHits) {
     profile = "yuanbao-web";
-  }
-
-  // Prefer ACP when URL or payload looks like session SSE with session/update.
-  if (vendorHint === "acp" && acpHits >= 1 && acpHits >= openaiHits) {
-    profile = "acp";
   }
 
   let resolvedVendor = vendorHint;


### PR DESCRIPTION
## Summary

ACP-over-HTTP session streams (SSE with `session/update` JSON-RPC, including `snapshot` / `update` frames) currently fall through as `generic`, so Conversation stays empty even though Events/Raw work.

This PR adds an `acp` vendor profile in the existing `ai-merge` extension point:

- Detect ACP wire shapes and common `/api/agents/:id/events` URLs
- Merge `agent_message*` → Content, `agent_thought*` → Thinking, `plan`/`plan_update` → Thinking, `tool_call*` → Tools
- Map turn end via `state_update` + `stopReason`, and `usage_update` → Meta
- CI fixture under `fixtures/vendors/acp/`

No UI / channel-model changes — same Conversation surface as other vendors.

## Checklist

- [x] `pnpm format:check && pnpm lint && pnpm test && pnpm typecheck && pnpm build` passes locally
- [x] UI / capture changes were smoke-tested (`pnpm demo` or a real page)
- [x] Shared logic changes include or update tests when practical
- [x] No secrets or personal data in fixtures / screenshots
- [x] If `detect` / `ai-merge` / vendor fixtures changed, `pnpm test` covers them

## Test plan

- [ ] `pnpm test` — `vendor-fixtures` includes `acp`
- [ ] Load unpacked `dist/`, open an ACP-over-HTTP session SSE page, refresh, trigger a turn
- [ ] Streams sidebar shows the events URL; Conversation profile chip is `acp`
- [ ] Content / Thinking / Tools populate; Finish comes from `stopReason` (e.g. `end_turn`), not tool status
- [ ] Existing vendor fixtures still pass (deepseek/doubao/kimi/qwen/chatglm/yuanbao)


Made with [Cursor](https://cursor.com)