### PR TITLE
fix(panel): request payload context menu + release 1.2.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ A clear description of what went wrong.
 
 - Chrome version:
 - OS:
-- Extension build: (commit SHA or `v1.2.2` / local `dist`)
+- Extension build: (commit SHA or `v1.2.3` / local `dist`)
 
 ## Steps to reproduce
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist.zip
 .release-staging/
 website/node_modules/
 website/dist/
+website/public/screenshots/*
+!website/public/screenshots/.gitkeep
 .agents/
 *.local
 .DS_Store

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -836,6 +836,12 @@
   "requestPayloadSource": {
     "message": "Source"
   },
+  "requestBodyCopy": {
+    "message": "Copy"
+  },
+  "requestBodyCopyTitle": {
+    "message": "Copy request payload"
+  },
   "requestBodyHint": {
     "message": "Best-effort preview from the page request body (up to 256KB)."
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -836,6 +836,12 @@
   "requestPayloadSource": {
     "message": "原始文本"
   },
+  "requestBodyCopy": {
+    "message": "复制"
+  },
+  "requestBodyCopyTitle": {
+    "message": "复制请求体原文"
+  },
   "requestBodyHint": {
     "message": "从页面请求体尽力采集的预览（上限 256KB）。"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extName__",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "__MSG_extDescription__",
   "icons": {
     "16": "icons/icon-16.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sse-devtools-panel",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "license": "MIT",
   "homepage": "https://fatmii.github.io/sse-devtools-panel/",

--- a/src/panel/panel.html
+++ b/src/panel/panel.html
@@ -441,12 +441,16 @@
       <span id="toast-text"></span>
     </div>
 
-    <div id="row-context-menu" class="context-menu" hidden>
-      <button type="button" data-action="copy-data" data-i18n="copyData">Copy Data</button>
-      <button type="button" data-action="copy-json-value" data-i18n="jsonCopyValue">
+    <div id="row-context-menu" class="context-menu" role="menu" hidden>
+      <button type="button" role="menuitem" data-action="copy-data" data-i18n="copyData">
+        Copy Data
+      </button>
+      <button type="button" role="menuitem" data-action="copy-json-value" data-i18n="jsonCopyValue">
         Copy value
       </button>
-      <button type="button" data-action="copy-json-path" data-i18n="jsonCopyPath">Copy path</button>
+      <button type="button" role="menuitem" data-action="copy-json-path" data-i18n="jsonCopyPath">
+        Copy path
+      </button>
     </div>
 
     <dialog id="app-dialog" class="app-dialog">

--- a/src/panel/panel.ts
+++ b/src/panel/panel.ts
@@ -142,6 +142,7 @@ import {
   navigateDrawer,
   renderEvents,
   selectEventByIndex,
+  showContextMenu,
   updateDrawerNavButtons,
   bindJsonTreeContextMenu,
 } from "./views/events-view";
@@ -664,7 +665,11 @@ function renderTimelineForSelection(record: StreamRecord | undefined): void {
 }
 
 function renderRequestForSelection(record: StreamRecord | undefined): void {
-  renderRequest(record, { onBindJsonTreeContextMenu: bindJsonTreeContextMenu });
+  renderRequest(record, {
+    onBindJsonTreeContextMenu: bindJsonTreeContextMenu,
+    copyText,
+    onShowPayloadContextMenu: showContextMenu,
+  });
 }
 
 function renderConversationForSelection(record: StreamRecord | undefined): void {
@@ -904,8 +909,12 @@ function setupActions(): void {
   });
 
   document.addEventListener("click", (e) => {
-    hideContextMenu();
     const target = e.target as Node | null;
+    const inContextMenu = Boolean(target && elContextMenu.contains(target));
+    // Menu item handler owns dismiss; don't clear payload mid-action.
+    if (!inContextMenu) {
+      hideContextMenu();
+    }
     if (
       (elExportMenu && target && elExportMenu.contains(target)) ||
       (elMoreMenu && target && elMoreMenu.contains(target)) ||

--- a/src/panel/panel.ts
+++ b/src/panel/panel.ts
@@ -1044,7 +1044,7 @@ function refreshLocaleUi(): void {
   applyDomI18n();
   setUiPaused(state.uiPaused, pauseHooks);
   if (elStatusbarLocale) {
-    const version = chrome.runtime.getManifest?.().version ?? "1.2.2";
+    const version = chrome.runtime.getManifest?.().version ?? "1.2.3";
     elStatusbarLocale.textContent =
       getActiveLocale() === "zh_CN" ? `中文 · ${version}` : `EN · ${version}`;
   }

--- a/src/panel/styles/events.css
+++ b/src/panel/styles/events.css
@@ -284,6 +284,13 @@ body.is-resizing {
   font: var(--text-sm) / 1.65 var(--mono);
 }
 
+.drawer-body .json-tree {
+  width: 100%;
+  min-width: max-content;
+  font-size: var(--text-base);
+  line-height: 1.5;
+}
+
 .event-body-text {
   margin: 0;
   padding: 2px 4px;
@@ -297,11 +304,13 @@ body.is-resizing {
 .context-menu {
   position: fixed;
   z-index: 1000;
-  min-width: 140px;
-  padding: 4px;
+  /* Network Soft Context Menu: wider than toolbar chip menus so labels breathe. */
+  min-width: 180px;
+  max-width: min(320px, calc(100vw - 16px));
+  padding: var(--space-1) 0;
   background: var(--surface-1);
-  border: 1px solid var(--stroke);
-  border-radius: var(--r-md);
+  border: 1px solid var(--stroke-strong);
+  border-radius: var(--r-sm);
   box-shadow: var(--shadow-menu);
 }
 
@@ -311,14 +320,32 @@ body.is-resizing {
 
 .context-menu button {
   display: block;
-  width: 100%;
+  width: calc(100% - 8px);
+  margin: 0 4px;
   text-align: left;
   border: none;
   border-radius: var(--r-sm);
   background: transparent;
-  padding: 6px 10px;
+  color: var(--text);
+  font: var(--text-base) / 1.35 var(--sans);
+  padding: 5px 10px;
+  white-space: nowrap;
+  cursor: default;
 }
 
-.context-menu button:hover {
-  background: var(--surface-hover);
+/* Author `display: block` otherwise overrides the HTML hidden attribute. */
+.context-menu button[hidden] {
+  display: none !important;
+}
+
+.context-menu button:hover,
+.context-menu button:focus-visible {
+  background: var(--accent);
+  color: #fff;
+  outline: none;
+}
+
+.context-menu button:active {
+  background: var(--accent-strong);
+  color: #fff;
 }

--- a/src/panel/styles/request.css
+++ b/src/panel/styles/request.css
@@ -62,6 +62,38 @@
   gap: var(--space-3);
 }
 
+.request-section-title-row .request-view-toggle {
+  margin-left: auto;
+}
+
+.request-payload-copy {
+  flex-shrink: 0;
+  border: 1px solid var(--stroke);
+  border-radius: var(--r-sm);
+  background: var(--surface-1);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  padding: 3px 8px;
+  cursor: pointer;
+  transition:
+    color var(--duration-ui) var(--ease-out),
+    background-color var(--duration-ui) var(--ease-out),
+    border-color var(--duration-ui) var(--ease-out);
+}
+
+.request-payload-copy:hover:not(:disabled) {
+  color: var(--accent-strong);
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--stroke));
+  background: var(--accent-wash);
+}
+
+.request-payload-copy:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 .request-section-title {
   color: var(--text-muted);
   font-size: var(--text-xs);
@@ -182,6 +214,29 @@
 
 .request-payload-content {
   min-height: 0;
+  min-width: 0;
+  width: 100%;
+}
+
+/* Parsed JSON tree: same chrome as Source pane / Network payload viewer. */
+.request-payload-content:has(.json-tree) {
+  padding: 6px 8px;
+  border: 1px solid var(--stroke);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  max-height: min(60vh, 520px);
+  overflow: auto;
+}
+
+.request-payload-content .json-tree {
+  width: 100%;
+  min-width: max-content;
+  font-size: var(--text-base);
+  line-height: 1.5;
+}
+
+.request-payload-content .request-headers-table {
+  width: 100%;
 }
 
 .request-payload-text {
@@ -195,6 +250,6 @@
   line-height: 1.55;
   white-space: pre-wrap;
   word-break: break-word;
-  max-height: 420px;
+  max-height: min(60vh, 520px);
   overflow: auto;
 }

--- a/src/panel/views/events-view.ts
+++ b/src/panel/views/events-view.ts
@@ -371,14 +371,7 @@ export function showContextMenu(x: number, y: number, data: string): void {
   if (elMenuCopyData) elMenuCopyData.hidden = false;
   if (elMenuCopyJsonValue) elMenuCopyJsonValue.hidden = true;
   if (elMenuCopyJsonPath) elMenuCopyJsonPath.hidden = true;
-  elContextMenu.hidden = false;
-  const pad = 4;
-  const menuW = elContextMenu.offsetWidth || 140;
-  const menuH = elContextMenu.offsetHeight || 36;
-  const left = Math.min(x, window.innerWidth - menuW - pad);
-  const top = Math.min(y, window.innerHeight - menuH - pad);
-  elContextMenu.style.left = `${Math.max(pad, left)}px`;
-  elContextMenu.style.top = `${Math.max(pad, top)}px`;
+  positionContextMenu(x, y);
 }
 
 export function showJsonTreeContextMenu(x: number, y: number, path: string, value?: string): void {
@@ -386,9 +379,14 @@ export function showJsonTreeContextMenu(x: number, y: number, path: string, valu
   if (elMenuCopyData) elMenuCopyData.hidden = true;
   if (elMenuCopyJsonValue) elMenuCopyJsonValue.hidden = value == null;
   if (elMenuCopyJsonPath) elMenuCopyJsonPath.hidden = false;
+  positionContextMenu(x, y);
+}
+
+function positionContextMenu(x: number, y: number): void {
   elContextMenu.hidden = false;
-  const pad = 4;
-  const menuW = elContextMenu.offsetWidth || 180;
+  // Measure after unhide so width reflects currently visible items.
+  const pad = 8;
+  const menuW = Math.max(elContextMenu.offsetWidth || 0, 180);
   const menuH = elContextMenu.offsetHeight || 72;
   const left = Math.min(x, window.innerWidth - menuW - pad);
   const top = Math.min(y, window.innerHeight - menuH - pad);

--- a/src/panel/views/request-view-ui.ts
+++ b/src/panel/views/request-view-ui.ts
@@ -18,6 +18,8 @@ let requestViewFingerprint = "";
 
 export type RenderRequestOptions = {
   onBindJsonTreeContextMenu: (tree: HTMLElement) => void;
+  copyText: (text: string, notify?: boolean) => Promise<void>;
+  onShowPayloadContextMenu: (x: number, y: number, data: string) => void;
 };
 
 export function resetRequestViewState(): void {
@@ -291,6 +293,18 @@ export function renderRequest(
   sourceBtn.textContent = t("requestPayloadSource");
   viewToggle.append(parsedBtn, sourceBtn);
   bodyTitleRow.appendChild(viewToggle);
+
+  const copyBtn = document.createElement("button");
+  copyBtn.type = "button";
+  copyBtn.className = "request-payload-copy";
+  copyBtn.textContent = t("requestBodyCopy");
+  copyBtn.title = t("requestBodyCopyTitle");
+  copyBtn.disabled = !payload;
+  copyBtn.addEventListener("click", () => {
+    if (!payload) return;
+    void options.copyText(payload, true);
+  });
+  bodyTitleRow.appendChild(copyBtn);
   bodySection.appendChild(bodyTitleRow);
 
   const bodyHint = document.createElement("div");
@@ -318,6 +332,10 @@ export function renderRequest(
       const pre = document.createElement("pre");
       pre.className = "request-payload-text";
       pre.textContent = payload;
+      pre.addEventListener("contextmenu", (e) => {
+        e.preventDefault();
+        options.onShowPayloadContextMenu(e.clientX, e.clientY, payload);
+      });
       bodyContent.appendChild(pre);
       return;
     }
@@ -335,6 +353,10 @@ export function renderRequest(
     const pre = document.createElement("pre");
     pre.className = "request-payload-text";
     pre.textContent = payload;
+    pre.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+      options.onShowPayloadContextMenu(e.clientX, e.clientY, payload);
+    });
     bodyContent.appendChild(pre);
   };
 

--- a/src/panel/widgets/json-tree.ts
+++ b/src/panel/widgets/json-tree.ts
@@ -387,6 +387,7 @@ function renderCollection(
       x: e.clientX,
       y: e.clientY,
       path,
+      copyValue: toCopyValue(value, type),
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix request payload JSON context menu: hidden items were still visible (CSS), collections lacked copyValue, Source view had no copy action
- Align Soft Context Menu / parsed payload chrome with Network-like styling
- Ignore synced `website/public/screenshots/*` artifacts
- Bump version to **1.2.3**

## Test plan
- [ ] Request → Payload → Parsed: right-click shows only applicable copy items; Copy value / Copy path work
- [ ] Request → Payload → Source: Copy button + right-click Copy Data work
- [ ] `pnpm test && pnpm lint && pnpm build`