### PR TITLE
fix: still capture SSE after hot reload overwrites window.fetch

### DIFF
--- a/src/content/inject/__tests__/install-chained-global.test.ts
+++ b/src/content/inject/__tests__/install-chained-global.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { installChainedGlobal } from "../install-chained-global";
+
+describe("installChainedGlobal", () => {
+  it("keeps our entry after reassignment to a bare downstream", () => {
+    const host: { fn?: (n: number) => number } = {};
+    const native = (n: number) => n;
+    host.fn = native;
+
+    let seen = 0;
+    const { entry } = installChainedGlobal(host, "fn", native, ({ applyDownstream }) => {
+      return (n: number) => {
+        seen += 1;
+        return applyDownstream(undefined, [n]) as number;
+      };
+    });
+
+    expect(host.fn).toBe(entry);
+    expect(host.fn!(3)).toBe(3);
+    expect(seen).toBe(1);
+
+    // Simulate another script replacing the implementation.
+    host.fn = ((n: number) => n * 10) as typeof native;
+    expect(host.fn).toBe(entry);
+    expect(host.fn!(3)).toBe(30);
+    expect(seen).toBe(2);
+  });
+
+  it("survives wrap-with-prev without infinite recursion", () => {
+    const host: { fn?: (n: number) => number } = {};
+    const native = (n: number) => n + 1;
+    host.fn = native;
+
+    let hooks = 0;
+    const { entry } = installChainedGlobal(host, "fn", native, ({ applyDownstream }) => {
+      return (n: number) => {
+        hooks += 1;
+        return applyDownstream(undefined, [n]) as number;
+      };
+    });
+
+    const prev = host.fn!;
+    host.fn = ((n: number) => prev(n) * 2) as typeof native;
+
+    expect(host.fn).toBe(entry);
+    // entry → theirWrap → entry (reentry→native(3)=4) → theirWrap returns 8
+    expect(host.fn!(3)).toBe(8);
+    expect(hooks).toBe(1);
+  });
+
+  it("ignores assigning the entry back onto itself", () => {
+    const host: { fn?: (n: number) => number } = {};
+    const native = (n: number) => n;
+    host.fn = native;
+
+    const { entry, getDownstream } = installChainedGlobal(
+      host,
+      "fn",
+      native,
+      ({ applyDownstream }) => {
+        return (n: number) => applyDownstream(undefined, [n]) as number;
+      },
+    );
+
+    host.fn = entry;
+    expect(getDownstream()).toBe(native);
+    expect(host.fn!(2)).toBe(2);
+  });
+
+  it("breaks ctor wrap-with-prev loops via native reentry", () => {
+    class Native {
+      value: number;
+      constructor(value: number) {
+        this.value = value;
+      }
+    }
+
+    const host: { Ctor?: typeof Native } = { Ctor: Native };
+
+    const { entry } = installChainedGlobal(host, "Ctor", Native, ({ constructDownstream }) => {
+      function Patched(this: Native, value: number): Native {
+        return constructDownstream([value]) as Native;
+      }
+      return Patched as unknown as typeof Native;
+    });
+
+    const Prev = host.Ctor!;
+    host.Ctor = class Wrapped extends Native {
+      constructor(value: number) {
+        const inner = new Prev(value * 2);
+        super(inner.value);
+      }
+    };
+
+    expect(host.Ctor).toBe(entry);
+    const instance = new (host.Ctor as typeof Native)(3);
+    // Patched → Wrapped → Prev(=entry, reentry) → Native(6)
+    expect(instance.value).toBe(6);
+  });
+});

--- a/src/content/inject/install-chained-global.ts
+++ b/src/content/inject/install-chained-global.ts
@@ -1,0 +1,87 @@
+/**
+ * Install a window (or object) property that survives later reassignment.
+ *
+ * Page scripts and other tools may wrap or replace globals, e.g.:
+ *   const prev = window.fetch;
+ *   window.fetch = (...args) => prev(...args);
+ * A plain `window.fetch = ourHook` is then lost. With get/set, the getter always
+ * returns our entry while the setter updates the downstream callee.
+ *
+ * Re-entrancy: if a later wrapper closes over our entry (prev === ourHook),
+ * calling through downstream would recurse into our hook. A Proxy apply/construct
+ * guard routes re-entry to `native` (value at install time) so instrumentation
+ * runs once and the cycle breaks.
+ */
+
+export type ChainedGlobalHandle<T> = {
+  /** Always the installed entry (what getters return). */
+  entry: T;
+  /** Current downstream callee; updated when the property is reassigned. */
+  getDownstream: () => T;
+};
+
+export type ChainedGlobalApi<T> = {
+  getDownstream: () => T;
+  applyDownstream: (self: unknown, args: unknown[]) => unknown;
+  constructDownstream: (args: unknown[]) => object;
+};
+
+export function installChainedGlobal<T extends object>(
+  target: object,
+  key: string,
+  native: T,
+  createEntry: (api: ChainedGlobalApi<T>) => T,
+): ChainedGlobalHandle<T> {
+  let downstream: T = native;
+  let depth = 0;
+
+  const getDownstream = (): T => downstream;
+
+  const applyDownstream = (self: unknown, args: unknown[]): unknown =>
+    Reflect.apply(getDownstream() as (...a: unknown[]) => unknown, self, args);
+
+  const constructDownstream = (args: unknown[]): object =>
+    Reflect.construct(getDownstream() as new (...a: unknown[]) => object, args);
+
+  const rawEntry = createEntry({ getDownstream, applyDownstream, constructDownstream });
+
+  const entry = new Proxy(rawEntry, {
+    apply(t, thisArg, args) {
+      if (depth > 0) {
+        return Reflect.apply(native as (...a: unknown[]) => unknown, thisArg, args);
+      }
+      depth += 1;
+      try {
+        return Reflect.apply(t as (...a: unknown[]) => unknown, thisArg, args);
+      } finally {
+        depth -= 1;
+      }
+    },
+    construct(t, args, newTarget) {
+      if (depth > 0) {
+        return Reflect.construct(native as new (...a: unknown[]) => object, args, newTarget);
+      }
+      depth += 1;
+      try {
+        return Reflect.construct(t as new (...a: unknown[]) => object, args, newTarget);
+      } finally {
+        depth -= 1;
+      }
+    },
+  }) as T;
+
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    get(): T {
+      return entry;
+    },
+    set(next: T): void {
+      if (next === entry || next === rawEntry) return;
+      if (next == null) return;
+      downstream = next;
+    },
+  });
+
+  return { entry, getDownstream };
+}

--- a/src/content/inject/patch-eventsource.ts
+++ b/src/content/inject/patch-eventsource.ts
@@ -1,4 +1,5 @@
 import type { StreamCloseReason } from "../../shared/types";
+import { installChainedGlobal } from "./install-chained-global";
 import type { PostChunk, PostEnd, PostError, PostReconnect, PostStart } from "./types";
 
 export function toSseFrame(typeName: string, data: string, id?: string): string {
@@ -25,128 +26,130 @@ export function patchEventSource(
   postError: PostError,
   postReconnect: PostReconnect,
 ): void {
-  const OriginalEventSource = window.EventSource;
+  const NativeEventSource = window.EventSource;
 
-  function PatchedEventSource(
-    this: EventSource,
-    url: string | URL,
-    eventSourceInitDict?: EventSourceInit,
-  ): EventSource {
-    const instance = new OriginalEventSource(url, eventSourceInitDict);
-    const requestId = nextId();
-    const href = typeof url === "string" ? url : url.href;
-    let ended = false;
-    let clientClosed = false;
-    let reconnectCount = 0;
-    let lastEventId = "";
+  installChainedGlobal(window, "EventSource", NativeEventSource, ({ constructDownstream }) => {
+    function PatchedEventSource(
+      this: EventSource,
+      url: string | URL,
+      eventSourceInitDict?: EventSourceInit,
+    ): EventSource {
+      const instance = constructDownstream([url, eventSourceInitDict]) as EventSource;
+      const requestId = nextId();
+      const href = typeof url === "string" ? url : url.href;
+      let ended = false;
+      let clientClosed = false;
+      let reconnectCount = 0;
+      let lastEventId = "";
 
-    postStart({
-      requestId,
-      url: href,
-      method: "GET",
-      contentType: "text/event-stream",
-      transport: "eventsource",
-      streamKind: "sse",
-      startedAt: Date.now(),
-    });
-
-    const finish = (mode: "end" | "error", closeReason: StreamCloseReason, message?: string) => {
-      if (ended) return;
-      ended = true;
-      const endedAt = Date.now();
-      if (mode === "error") {
-        postError({
-          requestId,
-          message: message || "EventSource error",
-          endedAt,
-          closeReason:
-            closeReason === "abort" || closeReason === "http_error" ? closeReason : "error",
-        });
-      } else {
-        postEnd({
-          requestId,
-          endedAt,
-          closeReason: closeReason === "abort" ? "abort" : "complete",
-        });
-      }
-    };
-
-    const onMessage = (ev: Event) => {
-      const me = ev as MessageEvent;
-      const typeName = me.type && me.type !== "message" ? me.type : "message";
-      const data = typeof me.data === "string" ? me.data : String(me.data ?? "");
-      const eventId =
-        typeof me.lastEventId === "string" && me.lastEventId ? me.lastEventId : undefined;
-      if (eventId) lastEventId = eventId;
-      postChunk({ requestId, text: toSseFrame(typeName, data, eventId) });
-    };
-
-    const trackedTypes = new Set<string>(["message"]);
-    const originalAdd = instance.addEventListener.bind(instance);
-
-    const trackType = (type: string): void => {
-      if (!type || type === "error" || type === "open") return;
-      if (trackedTypes.has(type)) return;
-      trackedTypes.add(type);
-      originalAdd(type, onMessage);
-    };
-
-    originalAdd("message", onMessage);
-
-    instance.addEventListener = ((
-      type: string,
-      listener: EventListenerOrEventListenerObject | null,
-      options?: boolean | AddEventListenerOptions,
-    ) => {
-      trackType(type);
-      return originalAdd(type, listener as EventListener, options);
-    }) as typeof instance.addEventListener;
-
-    instance.addEventListener("error", () => {
-      if (ended) return;
-      if (instance.readyState === OriginalEventSource.CLOSED) {
-        if (clientClosed) {
-          finish("error", "abort", "EventSource closed by client");
-        } else {
-          finish("error", "error", "EventSource connection closed");
-        }
-        return;
-      }
-      // CONNECTING — browser will auto-reconnect; keep the stream open.
-      reconnectCount += 1;
-      postReconnect({
+      postStart({
         requestId,
-        at: Date.now(),
-        reconnectCount,
-        lastEventId: lastEventId || undefined,
+        url: href,
+        method: "GET",
+        contentType: "text/event-stream",
+        transport: "eventsource",
+        streamKind: "sse",
+        startedAt: Date.now(),
       });
-    });
 
-    const originalClose = instance.close.bind(instance);
-    instance.close = (): void => {
-      clientClosed = true;
-      originalClose();
-      finish("error", "abort", "EventSource closed by client");
-    };
-
-    // Legacy / convenience handlers: `es.onping = fn` (in addition to addEventListener).
-    return new Proxy(instance, {
-      set(target, prop, value, receiver) {
-        if (typeof prop === "string") {
-          const type = eventTypeFromOnProperty(prop);
-          if (type) trackType(type);
+      const finish = (mode: "end" | "error", closeReason: StreamCloseReason, message?: string) => {
+        if (ended) return;
+        ended = true;
+        const endedAt = Date.now();
+        if (mode === "error") {
+          postError({
+            requestId,
+            message: message || "EventSource error",
+            endedAt,
+            closeReason:
+              closeReason === "abort" || closeReason === "http_error" ? closeReason : "error",
+          });
+        } else {
+          postEnd({
+            requestId,
+            endedAt,
+            closeReason: closeReason === "abort" ? "abort" : "complete",
+          });
         }
-        return Reflect.set(target, prop, value, receiver);
-      },
+      };
+
+      const onMessage = (ev: Event) => {
+        const me = ev as MessageEvent;
+        const typeName = me.type && me.type !== "message" ? me.type : "message";
+        const data = typeof me.data === "string" ? me.data : String(me.data ?? "");
+        const eventId =
+          typeof me.lastEventId === "string" && me.lastEventId ? me.lastEventId : undefined;
+        if (eventId) lastEventId = eventId;
+        postChunk({ requestId, text: toSseFrame(typeName, data, eventId) });
+      };
+
+      const trackedTypes = new Set<string>(["message"]);
+      const originalAdd = instance.addEventListener.bind(instance);
+
+      const trackType = (type: string): void => {
+        if (!type || type === "error" || type === "open") return;
+        if (trackedTypes.has(type)) return;
+        trackedTypes.add(type);
+        originalAdd(type, onMessage);
+      };
+
+      originalAdd("message", onMessage);
+
+      instance.addEventListener = ((
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions,
+      ) => {
+        trackType(type);
+        return originalAdd(type, listener as EventListener, options);
+      }) as typeof instance.addEventListener;
+
+      instance.addEventListener("error", () => {
+        if (ended) return;
+        if (instance.readyState === NativeEventSource.CLOSED) {
+          if (clientClosed) {
+            finish("error", "abort", "EventSource closed by client");
+          } else {
+            finish("error", "error", "EventSource connection closed");
+          }
+          return;
+        }
+        // CONNECTING — browser will auto-reconnect; keep the stream open.
+        reconnectCount += 1;
+        postReconnect({
+          requestId,
+          at: Date.now(),
+          reconnectCount,
+          lastEventId: lastEventId || undefined,
+        });
+      });
+
+      const originalClose = instance.close.bind(instance);
+      instance.close = (): void => {
+        clientClosed = true;
+        originalClose();
+        finish("error", "abort", "EventSource closed by client");
+      };
+
+      // Legacy / convenience handlers: `es.onping = fn` (in addition to addEventListener).
+      return new Proxy(instance, {
+        set(target, prop, value, receiver) {
+          if (typeof prop === "string") {
+            const type = eventTypeFromOnProperty(prop);
+            if (type) trackType(type);
+          }
+          return Reflect.set(target, prop, value, receiver);
+        },
+      });
+    }
+
+    PatchedEventSource.prototype = NativeEventSource.prototype;
+    Object.defineProperty(PatchedEventSource, "CONNECTING", {
+      value: NativeEventSource.CONNECTING,
     });
-  }
+    Object.defineProperty(PatchedEventSource, "OPEN", { value: NativeEventSource.OPEN });
+    Object.defineProperty(PatchedEventSource, "CLOSED", { value: NativeEventSource.CLOSED });
 
-  PatchedEventSource.prototype = OriginalEventSource.prototype;
-  Object.defineProperty(PatchedEventSource, "CONNECTING", {
-    value: OriginalEventSource.CONNECTING,
+    return PatchedEventSource as unknown as typeof EventSource;
   });
-  Object.defineProperty(PatchedEventSource, "OPEN", { value: OriginalEventSource.OPEN });
-  Object.defineProperty(PatchedEventSource, "CLOSED", { value: OriginalEventSource.CLOSED });
-
-  window.EventSource = PatchedEventSource as unknown as typeof EventSource;
 }

--- a/src/content/inject/patch-fetch.ts
+++ b/src/content/inject/patch-fetch.ts
@@ -7,6 +7,7 @@ import {
   resolveMethod,
   resolveUrl,
 } from "./headers";
+import { installChainedGlobal } from "./install-chained-global";
 import { captureFetchResponseBody, createConnectJsonSink, createFetchTextSink } from "./stream";
 import type { PostChunk, PostDiscard, PostEnd, PostError, PostStart } from "./types";
 
@@ -18,93 +19,97 @@ export function patchFetch(
   postError: PostError,
   postDiscard: PostDiscard,
 ): void {
-  const originalFetch = window.fetch.bind(window);
+  const nativeFetch = window.fetch.bind(window);
 
-  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const requestId = nextId();
-    const url = resolveUrl(input);
-    const method = resolveMethod(input, init);
-    const startedAt = Date.now();
-    const reqMeta = await collectFetchRequestMeta(input, init);
-    let announced = false;
+  installChainedGlobal(window, "fetch", nativeFetch, ({ applyDownstream }) => {
+    const patched: typeof fetch = async (input, init) => {
+      const requestId = nextId();
+      const url = resolveUrl(input);
+      const method = resolveMethod(input, init);
+      const startedAt = Date.now();
+      const reqMeta = await collectFetchRequestMeta(input, init);
+      let announced = false;
 
-    const announce = (extra: {
-      status?: number;
-      statusText?: string;
-      contentType?: string;
-      streamKind: StreamKind;
-      url?: string;
-      responseHeaders?: Record<string, string>;
-    }): void => {
-      postStart({
-        requestId,
-        url: extra.url ?? url,
-        method,
-        status: extra.status,
-        statusText: extra.statusText,
-        contentType: extra.contentType,
+      const announce = (extra: {
+        status?: number;
+        statusText?: string;
+        contentType?: string;
+        streamKind: StreamKind;
+        url?: string;
+        responseHeaders?: Record<string, string>;
+      }): void => {
+        postStart({
+          requestId,
+          url: extra.url ?? url,
+          method,
+          status: extra.status,
+          statusText: extra.statusText,
+          contentType: extra.contentType,
+          requestHeaders: reqMeta.headers,
+          responseHeaders: extra.responseHeaders,
+          requestPayloadPreview: reqMeta.payloadPreview,
+          requestPayloadTruncated: reqMeta.payloadTruncated,
+          transport: "fetch",
+          streamKind: extra.streamKind,
+          startedAt,
+        });
+        announced = true;
+      };
+
+      const pendingKind = guessStreamKindFromRequest({
         requestHeaders: reqMeta.headers,
-        responseHeaders: extra.responseHeaders,
+        url,
         requestPayloadPreview: reqMeta.payloadPreview,
-        requestPayloadTruncated: reqMeta.payloadTruncated,
-        transport: "fetch",
-        streamKind: extra.streamKind,
-        startedAt,
       });
-      announced = true;
+      if (pendingKind) {
+        announce({ streamKind: pendingKind });
+      }
+
+      try {
+        const response = (await applyDownstream(window, [input, init])) as Response;
+
+        const contentType = response.headers.get("content-type");
+        const streamKind = resolveStreamKind({
+          responseContentType: contentType,
+          requestHeaders: reqMeta.headers,
+          url: response.url || url,
+          requestPayloadPreview: reqMeta.payloadPreview,
+        });
+        if (!streamKind) {
+          if (announced) {
+            postDiscard(requestId);
+          }
+          return response;
+        }
+
+        announce({
+          status: response.status,
+          statusText: response.statusText || undefined,
+          contentType: contentType ?? undefined,
+          streamKind,
+          url: response.url || url,
+          responseHeaders: normalizeResponseHeaders(response.headers),
+        });
+
+        const sink =
+          streamKind === "connect-json"
+            ? createConnectJsonSink(requestId, postChunk, postEnd, postError)
+            : createFetchTextSink(requestId, postChunk, postEnd, postError);
+        return captureFetchResponseBody(response, sink);
+      } catch (err) {
+        if (announced) {
+          const classified = classifyThrownError(err);
+          postError({
+            requestId,
+            message: classified.message,
+            endedAt: Date.now(),
+            closeReason: classified.closeReason,
+          });
+        }
+        throw err;
+      }
     };
 
-    const pendingKind = guessStreamKindFromRequest({
-      requestHeaders: reqMeta.headers,
-      url,
-      requestPayloadPreview: reqMeta.payloadPreview,
-    });
-    if (pendingKind) {
-      announce({ streamKind: pendingKind });
-    }
-
-    try {
-      const response = await originalFetch(input, init);
-
-      const contentType = response.headers.get("content-type");
-      const streamKind = resolveStreamKind({
-        responseContentType: contentType,
-        requestHeaders: reqMeta.headers,
-        url: response.url || url,
-        requestPayloadPreview: reqMeta.payloadPreview,
-      });
-      if (!streamKind) {
-        if (announced) {
-          postDiscard(requestId);
-        }
-        return response;
-      }
-
-      announce({
-        status: response.status,
-        statusText: response.statusText || undefined,
-        contentType: contentType ?? undefined,
-        streamKind,
-        url: response.url || url,
-        responseHeaders: normalizeResponseHeaders(response.headers),
-      });
-
-      const sink =
-        streamKind === "connect-json"
-          ? createConnectJsonSink(requestId, postChunk, postEnd, postError)
-          : createFetchTextSink(requestId, postChunk, postEnd, postError);
-      return captureFetchResponseBody(response, sink);
-    } catch (err) {
-      if (announced) {
-        const classified = classifyThrownError(err);
-        postError({
-          requestId,
-          message: classified.message,
-          endedAt: Date.now(),
-          closeReason: classified.closeReason,
-        });
-      }
-      throw err;
-    }
-  };
+    return patched;
+  });
 }

--- a/src/content/inject/patch-xhr.ts
+++ b/src/content/inject/patch-xhr.ts
@@ -2,6 +2,7 @@ import { classifyHttpStatus } from "../../shared/stream-close";
 import type { StreamCloseReason, StreamTransport } from "../../shared/types";
 import { guessStreamKindFromRequest, resolveStreamKind } from "./detect";
 import { clipPayloadText, parseRawResponseHeaders, redactHeaderValue } from "./headers";
+import { installChainedGlobal } from "./install-chained-global";
 import type { PostChunk, PostDiscard, PostEnd, PostError, PostStart } from "./types";
 
 /**
@@ -16,238 +17,243 @@ export function patchXhr(
   postError: PostError,
   postDiscard: PostDiscard,
 ): void {
-  const OriginalXHR = window.XMLHttpRequest;
+  const NativeXHR = window.XMLHttpRequest;
 
-  function PatchedXHR(this: XMLHttpRequest): XMLHttpRequest {
-    const xhr = new OriginalXHR();
-    let method = "GET";
-    let url = "";
-    const requestHeaders: Record<string, string> = {};
-    let requestPayloadPreview: string | undefined;
-    let requestPayloadTruncated: boolean | undefined;
-    let requestId: string | null = null;
-    let startedAt: number | undefined;
-    let announced = false;
-    let captured = false;
-    let finished = false;
-    let lastLen = 0;
+  installChainedGlobal(window, "XMLHttpRequest", NativeXHR, ({ constructDownstream }) => {
+    function PatchedXHR(this: XMLHttpRequest): XMLHttpRequest {
+      const xhr = constructDownstream([]) as XMLHttpRequest;
+      let method = "GET";
+      let url = "";
+      const requestHeaders: Record<string, string> = {};
+      let requestPayloadPreview: string | undefined;
+      let requestPayloadTruncated: boolean | undefined;
+      let requestId: string | null = null;
+      let startedAt: number | undefined;
+      let announced = false;
+      let captured = false;
+      let finished = false;
+      let lastLen = 0;
 
-    const originalOpen = xhr.open.bind(xhr);
-    xhr.open = ((...args: Parameters<XMLHttpRequest["open"]>) => {
-      method = String(args[0] ?? "GET").toUpperCase();
-      url = String(args[1] ?? "");
-      return originalOpen(...args);
-    }) as XMLHttpRequest["open"];
+      const originalOpen = xhr.open.bind(xhr);
+      xhr.open = ((...args: Parameters<XMLHttpRequest["open"]>) => {
+        method = String(args[0] ?? "GET").toUpperCase();
+        url = String(args[1] ?? "");
+        return originalOpen(...args);
+      }) as XMLHttpRequest["open"];
 
-    const originalSetRequestHeader = xhr.setRequestHeader.bind(xhr);
-    xhr.setRequestHeader = ((name: string, value: string) => {
-      requestHeaders[name.toLowerCase()] = redactHeaderValue(name, String(value));
-      return originalSetRequestHeader(name, value);
-    }) as XMLHttpRequest["setRequestHeader"];
+      const originalSetRequestHeader = xhr.setRequestHeader.bind(xhr);
+      xhr.setRequestHeader = ((name: string, value: string) => {
+        requestHeaders[name.toLowerCase()] = redactHeaderValue(name, String(value));
+        return originalSetRequestHeader(name, value);
+      }) as XMLHttpRequest["setRequestHeader"];
 
-    const originalSend = xhr.send.bind(xhr);
-    xhr.send = ((body?: Document | XMLHttpRequestBodyInit | null) => {
-      if (body == null) {
-        requestPayloadPreview = undefined;
-        requestPayloadTruncated = undefined;
-      } else if (typeof body === "string") {
-        const clipped = clipPayloadText(body);
-        requestPayloadPreview = clipped.preview;
-        requestPayloadTruncated = clipped.truncated;
-      } else if (body instanceof URLSearchParams) {
-        const clipped = clipPayloadText(body.toString());
-        requestPayloadPreview = clipped.preview;
-        requestPayloadTruncated = clipped.truncated;
-      } else if (body instanceof FormData) {
-        const fields: string[] = [];
-        body.forEach((value, key) => {
-          if (typeof value === "string") fields.push(`${key}=${value}`);
-          else fields.push(`${key}=[blob:${value.type || "application/octet-stream"}]`);
+      const originalSend = xhr.send.bind(xhr);
+      xhr.send = ((body?: Document | XMLHttpRequestBodyInit | null) => {
+        if (body == null) {
+          requestPayloadPreview = undefined;
+          requestPayloadTruncated = undefined;
+        } else if (typeof body === "string") {
+          const clipped = clipPayloadText(body);
+          requestPayloadPreview = clipped.preview;
+          requestPayloadTruncated = clipped.truncated;
+        } else if (body instanceof URLSearchParams) {
+          const clipped = clipPayloadText(body.toString());
+          requestPayloadPreview = clipped.preview;
+          requestPayloadTruncated = clipped.truncated;
+        } else if (body instanceof FormData) {
+          const fields: string[] = [];
+          body.forEach((value, key) => {
+            if (typeof value === "string") fields.push(`${key}=${value}`);
+            else fields.push(`${key}=[blob:${value.type || "application/octet-stream"}]`);
+          });
+          const clipped = clipPayloadText(fields.join("&"));
+          requestPayloadPreview = clipped.preview;
+          requestPayloadTruncated = clipped.truncated;
+        } else if (body instanceof Blob) {
+          requestPayloadPreview = `[blob:${body.type || "application/octet-stream"}]`;
+          requestPayloadTruncated = false;
+        } else if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+          const bytes = body.byteLength;
+          requestPayloadPreview = `[binary:${bytes} bytes]`;
+          requestPayloadTruncated = false;
+        } else if (typeof Document !== "undefined" && body instanceof Document) {
+          requestPayloadPreview = "[document]";
+          requestPayloadTruncated = false;
+        } else {
+          requestPayloadPreview = "[payload]";
+          requestPayloadTruncated = false;
+        }
+
+        const pendingKind = guessStreamKindFromRequest({
+          requestHeaders: Object.keys(requestHeaders).length > 0 ? requestHeaders : undefined,
+          url,
+          requestPayloadPreview,
         });
-        const clipped = clipPayloadText(fields.join("&"));
-        requestPayloadPreview = clipped.preview;
-        requestPayloadTruncated = clipped.truncated;
-      } else if (body instanceof Blob) {
-        requestPayloadPreview = `[blob:${body.type || "application/octet-stream"}]`;
-        requestPayloadTruncated = false;
-      } else if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
-        const bytes = body.byteLength;
-        requestPayloadPreview = `[binary:${bytes} bytes]`;
-        requestPayloadTruncated = false;
-      } else if (typeof Document !== "undefined" && body instanceof Document) {
-        requestPayloadPreview = "[document]";
-        requestPayloadTruncated = false;
-      } else {
-        requestPayloadPreview = "[payload]";
-        requestPayloadTruncated = false;
-      }
+        // Connect+JSON is binary — XHR cannot capture it; do not flash a pending row.
+        if (pendingKind && pendingKind !== "connect-json") {
+          requestId = nextId();
+          startedAt = Date.now();
+          announced = true;
+          postStart({
+            requestId,
+            url,
+            method,
+            requestHeaders:
+              Object.keys(requestHeaders).length > 0 ? { ...requestHeaders } : undefined,
+            requestPayloadPreview,
+            requestPayloadTruncated,
+            transport: "xhr" satisfies StreamTransport,
+            streamKind: pendingKind,
+            startedAt,
+          });
+        }
 
-      const pendingKind = guessStreamKindFromRequest({
-        requestHeaders: Object.keys(requestHeaders).length > 0 ? requestHeaders : undefined,
-        url,
-        requestPayloadPreview,
-      });
-      // Connect+JSON is binary — XHR cannot capture it; do not flash a pending row.
-      if (pendingKind && pendingKind !== "connect-json") {
-        requestId = nextId();
-        startedAt = Date.now();
-        announced = true;
+        return originalSend(body);
+      }) as XMLHttpRequest["send"];
+
+      const tryStart = (): void => {
+        if (captured || finished) return;
+        if (xhr.readyState < NativeXHR.HEADERS_RECEIVED) return;
+
+        let contentType: string;
+        try {
+          contentType = xhr.getResponseHeader("content-type") ?? "";
+        } catch {
+          return;
+        }
+
+        const kind = resolveStreamKind({
+          responseContentType: contentType,
+          requestHeaders,
+          url,
+          requestPayloadPreview,
+        });
+        // Connect+JSON is binary length-prefixed — XHR responseText corrupts frames.
+        if (!kind || kind === "connect-json") {
+          if (announced && requestId) {
+            postDiscard(requestId);
+            announced = false;
+            requestId = null;
+          }
+          return;
+        }
+
+        captured = true;
+        if (!requestId) requestId = nextId();
+        if (startedAt === undefined) startedAt = Date.now();
+        lastLen = 0;
+
+        let responseHeaders: Record<string, string> | undefined;
+        let statusText: string | undefined;
+        try {
+          const raw = xhr.getAllResponseHeaders();
+          if (raw) responseHeaders = parseRawResponseHeaders(raw);
+        } catch {
+          // ignore
+        }
+        try {
+          statusText = xhr.statusText || undefined;
+        } catch {
+          // ignore
+        }
+
         postStart({
           requestId,
           url,
           method,
+          status: xhr.status || undefined,
+          statusText,
+          contentType: contentType || undefined,
           requestHeaders:
             Object.keys(requestHeaders).length > 0 ? { ...requestHeaders } : undefined,
+          responseHeaders:
+            responseHeaders && Object.keys(responseHeaders).length > 0
+              ? responseHeaders
+              : undefined,
           requestPayloadPreview,
           requestPayloadTruncated,
           transport: "xhr" satisfies StreamTransport,
-          streamKind: pendingKind,
+          streamKind: kind,
           startedAt,
         });
-      }
+      };
 
-      return originalSend(body);
-    }) as XMLHttpRequest["send"];
-
-    const tryStart = (): void => {
-      if (captured || finished) return;
-      if (xhr.readyState < OriginalXHR.HEADERS_RECEIVED) return;
-
-      let contentType: string;
-      try {
-        contentType = xhr.getResponseHeader("content-type") ?? "";
-      } catch {
-        return;
-      }
-
-      const kind = resolveStreamKind({
-        responseContentType: contentType,
-        requestHeaders,
-        url,
-        requestPayloadPreview,
-      });
-      // Connect+JSON is binary length-prefixed — XHR responseText corrupts frames.
-      if (!kind || kind === "connect-json") {
-        if (announced && requestId) {
-          postDiscard(requestId);
-          announced = false;
-          requestId = null;
+      const emitDelta = (): void => {
+        if (!captured || !requestId || finished) return;
+        // responseText is only available for default / text responseType
+        if (xhr.responseType && xhr.responseType !== "text") {
+          return;
         }
-        return;
-      }
+        try {
+          const text = xhr.responseText ?? "";
+          if (text.length > lastLen) {
+            const delta = text.slice(lastLen);
+            lastLen = text.length;
+            if (delta) {
+              postChunk({ requestId, text: delta });
+            }
+          }
+        } catch {
+          // Ignore if responseText is inaccessible mid-flight
+        }
+      };
 
-      captured = true;
-      if (!requestId) requestId = nextId();
-      if (startedAt === undefined) startedAt = Date.now();
-      lastLen = 0;
+      const finishOk = (): void => {
+        if (!captured || !requestId || finished) return;
+        finished = true;
+        emitDelta();
+        postEnd({ requestId, endedAt: Date.now(), closeReason: "complete" });
+      };
 
-      let responseHeaders: Record<string, string> | undefined;
-      let statusText: string | undefined;
-      try {
-        const raw = xhr.getAllResponseHeaders();
-        if (raw) responseHeaders = parseRawResponseHeaders(raw);
-      } catch {
-        // ignore
-      }
-      try {
-        statusText = xhr.statusText || undefined;
-      } catch {
-        // ignore
-      }
+      const finishErr = (
+        message: string,
+        closeReason: Extract<StreamCloseReason, "abort" | "error" | "http_error">,
+      ): void => {
+        if (!captured || !requestId || finished) return;
+        finished = true;
+        emitDelta();
+        postError({ requestId, message, endedAt: Date.now(), closeReason });
+      };
 
-      postStart({
-        requestId,
-        url,
-        method,
-        status: xhr.status || undefined,
-        statusText,
-        contentType: contentType || undefined,
-        requestHeaders: Object.keys(requestHeaders).length > 0 ? { ...requestHeaders } : undefined,
-        responseHeaders:
-          responseHeaders && Object.keys(responseHeaders).length > 0 ? responseHeaders : undefined,
-        requestPayloadPreview,
-        requestPayloadTruncated,
-        transport: "xhr" satisfies StreamTransport,
-        streamKind: kind,
-        startedAt,
-      });
-    };
-
-    const emitDelta = (): void => {
-      if (!captured || !requestId || finished) return;
-      // responseText is only available for default / text responseType
-      if (xhr.responseType && xhr.responseType !== "text") {
-        return;
-      }
-      try {
-        const text = xhr.responseText ?? "";
-        if (text.length > lastLen) {
-          const delta = text.slice(lastLen);
-          lastLen = text.length;
-          if (delta) {
-            postChunk({ requestId, text: delta });
+      xhr.addEventListener("readystatechange", () => {
+        tryStart();
+        if (xhr.readyState === NativeXHR.LOADING || xhr.readyState === NativeXHR.DONE) {
+          emitDelta();
+        }
+        if (xhr.readyState === NativeXHR.DONE && captured) {
+          if (xhr.status >= 400) {
+            const classified = classifyHttpStatus(xhr.status);
+            finishErr(classified.message, classified.closeReason);
+          } else {
+            finishOk();
           }
         }
-      } catch {
-        // Ignore if responseText is inaccessible mid-flight
-      }
-    };
+      });
 
-    const finishOk = (): void => {
-      if (!captured || !requestId || finished) return;
-      finished = true;
-      emitDelta();
-      postEnd({ requestId, endedAt: Date.now(), closeReason: "complete" });
-    };
-
-    const finishErr = (
-      message: string,
-      closeReason: Extract<StreamCloseReason, "abort" | "error" | "http_error">,
-    ): void => {
-      if (!captured || !requestId || finished) return;
-      finished = true;
-      emitDelta();
-      postError({ requestId, message, endedAt: Date.now(), closeReason });
-    };
-
-    xhr.addEventListener("readystatechange", () => {
-      tryStart();
-      if (xhr.readyState === OriginalXHR.LOADING || xhr.readyState === OriginalXHR.DONE) {
-        emitDelta();
-      }
-      if (xhr.readyState === OriginalXHR.DONE && captured) {
-        if (xhr.status >= 400) {
-          const classified = classifyHttpStatus(xhr.status);
-          finishErr(classified.message, classified.closeReason);
-        } else {
-          finishOk();
+      xhr.addEventListener("error", () => {
+        if (captured) {
+          finishErr("XMLHttpRequest network error", "error");
         }
-      }
+      });
+
+      xhr.addEventListener("abort", () => {
+        if (captured) {
+          finishErr("XMLHttpRequest aborted", "abort");
+        }
+      });
+
+      return xhr;
+    }
+
+    PatchedXHR.prototype = NativeXHR.prototype;
+    Object.defineProperties(PatchedXHR, {
+      UNSENT: { value: NativeXHR.UNSENT },
+      OPENED: { value: NativeXHR.OPENED },
+      HEADERS_RECEIVED: { value: NativeXHR.HEADERS_RECEIVED },
+      LOADING: { value: NativeXHR.LOADING },
+      DONE: { value: NativeXHR.DONE },
     });
 
-    xhr.addEventListener("error", () => {
-      if (captured) {
-        finishErr("XMLHttpRequest network error", "error");
-      }
-    });
-
-    xhr.addEventListener("abort", () => {
-      if (captured) {
-        finishErr("XMLHttpRequest aborted", "abort");
-      }
-    });
-
-    return xhr;
-  }
-
-  PatchedXHR.prototype = OriginalXHR.prototype;
-  Object.defineProperties(PatchedXHR, {
-    UNSENT: { value: OriginalXHR.UNSENT },
-    OPENED: { value: OriginalXHR.OPENED },
-    HEADERS_RECEIVED: { value: OriginalXHR.HEADERS_RECEIVED },
-    LOADING: { value: OriginalXHR.LOADING },
-    DONE: { value: OriginalXHR.DONE },
+    return PatchedXHR as unknown as typeof XMLHttpRequest;
   });
-
-  window.XMLHttpRequest = PatchedXHR as unknown as typeof XMLHttpRequest;
 }


### PR DESCRIPTION
## Summary
- Keep fetch / EventSource / XHR capture hooks when page scripts replace those globals (common after soft hot reload).
- Install chained getters so later wrappers do not drop capture without a full page refresh.

## Test plan
- [x] `pnpm test` / `pnpm typecheck` / `pnpm build`
- [ ] Soft hot-reload a Vue/Vite app, then trigger SSE — panel should still show the stream
- [ ] Sanity: Fetch SSE / EventSource / XHR on demo page still work after a normal refresh